### PR TITLE
Fix common definition pack->channel reference error

### DIFF
--- a/resources/common_definitions.xml
+++ b/resources/common_definitions.xml
@@ -112,8 +112,8 @@
           <audioChannelFormatIDRef>AC_00010002</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_00010003</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_00010004</audioChannelFormatIDRef>
+          <audioChannelFormatIDRef>AC_0001000a</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_0001000b</audioChannelFormatIDRef>
-          <audioChannelFormatIDRef>AC_0001000c</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_0001001c</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_0001001d</audioChannelFormatIDRef>
           <audioChannelFormatIDRef>AC_00010013</audioChannelFormatIDRef>


### PR DESCRIPTION
The pack AP_00010016 should refer to Side-Left and Side-Right, not Side-Right and Top-Centre as it does currently.
The error is also present in the excel sheet attached to BS.2094-1, but not the BS.2094-1 document itself.