### PR TITLE
Make constructors of adm elements explicit to avoid implicit conversions

### DIFF
--- a/include/adm/elements/audio_block_format_binaural.hpp
+++ b/include/adm/elements/audio_block_format_binaural.hpp
@@ -26,7 +26,7 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatBinaural(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatBinaural(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatBinaural(const AudioBlockFormatBinaural&) =
         default;

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -34,7 +34,7 @@ namespace adm {
     typedef AudioBlockFormatDirectSpeakersTag tag;
 
     template <typename... Parameters>
-    AudioBlockFormatDirectSpeakers(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatDirectSpeakers(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatDirectSpeakers(
         const AudioBlockFormatDirectSpeakers&) = default;

--- a/include/adm/elements/audio_block_format_hoa.hpp
+++ b/include/adm/elements/audio_block_format_hoa.hpp
@@ -42,9 +42,8 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatHoa(Order order,
-                        Degree degree,
-                        Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatHoa(Order order, Degree degree,
+                                 Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatHoa(const AudioBlockFormatHoa&) = default;
     ADM_EXPORT AudioBlockFormatHoa(AudioBlockFormatHoa&&) = default;
@@ -125,7 +124,8 @@ namespace adm {
     ADM_EXPORT Degree get(detail::ParameterTraits<Degree>::tag) const;
     ADM_EXPORT NfcRefDist get(detail::ParameterTraits<NfcRefDist>::tag) const;
     ADM_EXPORT ScreenRef get(detail::ParameterTraits<ScreenRef>::tag) const;
-    ADM_EXPORT Normalization get(detail::ParameterTraits<Normalization>::tag) const;
+    ADM_EXPORT Normalization
+        get(detail::ParameterTraits<Normalization>::tag) const;
     ADM_EXPORT Equation get(detail::ParameterTraits<Equation>::tag) const;
 
     ADM_EXPORT bool has(detail::ParameterTraits<AudioBlockFormatId>::tag) const;
@@ -145,7 +145,8 @@ namespace adm {
     ADM_EXPORT bool isDefault(detail::ParameterTraits<Rtime>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<NfcRefDist>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<ScreenRef>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Normalization>::tag) const;
+    ADM_EXPORT bool isDefault(
+        detail::ParameterTraits<Normalization>::tag) const;
 
     ADM_EXPORT void unset(detail::ParameterTraits<Rtime>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<Duration>::tag);
@@ -167,8 +168,8 @@ namespace adm {
   // ---- Implementation ---- //
 
   template <typename... Parameters>
-  AudioBlockFormatHoa::AudioBlockFormatHoa(Order order,
-      Degree degree, Parameters... optionalNamedArgs) {
+  AudioBlockFormatHoa::AudioBlockFormatHoa(Order order, Degree degree,
+                                           Parameters... optionalNamedArgs) {
     set(order);
     set(degree);
     detail::setNamedOptionHelper(

--- a/include/adm/elements/audio_block_format_id.hpp
+++ b/include/adm/elements/audio_block_format_id.hpp
@@ -36,7 +36,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioBlockFormatId(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_block_format_matrix.hpp
+++ b/include/adm/elements/audio_block_format_matrix.hpp
@@ -32,7 +32,7 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatMatrix(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatMatrix(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatMatrix(const AudioBlockFormatMatrix&) = default;
     ADM_EXPORT AudioBlockFormatMatrix(AudioBlockFormatMatrix&&) = default;

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -64,8 +64,8 @@ namespace adm {
     AudioBlockFormatObjects(CartesianPosition position,
                             Parameters... optionalNamedArgs);
     template <typename... Parameters>
-    AudioBlockFormatObjects(SphericalPosition position,
-                            Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatObjects(SphericalPosition position,
+                                     Parameters... optionalNamedArgs);
     ADM_EXPORT AudioBlockFormatObjects(const AudioBlockFormatObjects&) =
         default;
     ADM_EXPORT AudioBlockFormatObjects(AudioBlockFormatObjects&&) = default;

--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -184,8 +184,8 @@ namespace adm {
    private:
     friend class AudioChannelFormatAttorney;
 
-    ADM_EXPORT AudioChannelFormat(AudioChannelFormatName name,
-                                  TypeDescriptor channelType);
+    ADM_EXPORT explicit AudioChannelFormat(AudioChannelFormatName name,
+                                           TypeDescriptor channelType);
     ADM_EXPORT AudioChannelFormat(const AudioChannelFormat &) = default;
     ADM_EXPORT AudioChannelFormat(AudioChannelFormat &&) = default;
 
@@ -225,7 +225,8 @@ namespace adm {
                         const AudioBlockFormatBinaural &blockFormat);
 
     template <typename BlockFormat>
-    void assignId(BlockFormat &blockFormat, BlockFormat *previousBlock = nullptr);
+    void assignId(BlockFormat &blockFormat,
+                  BlockFormat *previousBlock = nullptr);
 
     template <typename BlockFormat>
     bool idUsed(const AudioBlockFormatId &id);

--- a/include/adm/elements/audio_channel_format_id.hpp
+++ b/include/adm/elements/audio_channel_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioChannelFormatId(Parameters... optionalNamedArgs);
+    explicit AudioChannelFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_content.hpp
+++ b/include/adm/elements/audio_content.hpp
@@ -188,7 +188,7 @@ namespace adm {
    private:
     friend class AudioContentAttorney;
 
-    ADM_EXPORT AudioContent(AudioContentName name);
+    ADM_EXPORT explicit AudioContent(AudioContentName name);
     ADM_EXPORT AudioContent(const AudioContent &) = default;
     ADM_EXPORT AudioContent(AudioContent &&) = default;
 

--- a/include/adm/elements/audio_content_id.hpp
+++ b/include/adm/elements/audio_content_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioContentId(Parameters... optionalNamedArgs);
+    explicit AudioContentId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -190,7 +190,7 @@ namespace adm {
    private:
     friend class AudioObjectAttorney;
 
-    ADM_EXPORT AudioObject(AudioObjectName name);
+    ADM_EXPORT explicit AudioObject(AudioObjectName name);
     ADM_EXPORT AudioObject(const AudioObject &) = default;
     ADM_EXPORT AudioObject(AudioObject &&) = default;
 

--- a/include/adm/elements/audio_object_id.hpp
+++ b/include/adm/elements/audio_object_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioObjectId(Parameters... optionalNamedArgs);
+    explicit AudioObjectId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_object_interaction.hpp
+++ b/include/adm/elements/audio_object_interaction.hpp
@@ -42,8 +42,8 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioObjectInteraction(OnOffInteract onOffInteract,
-                           Parameters... optionalNamedArgs);
+    explicit AudioObjectInteraction(OnOffInteract onOffInteract,
+                                    Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_pack_format.hpp
+++ b/include/adm/elements/audio_pack_format.hpp
@@ -164,8 +164,8 @@ namespace adm {
    protected:
     friend class AudioPackFormatAttorney;
 
-    ADM_EXPORT AudioPackFormat(AudioPackFormatName name,
-                               TypeDescriptor channelType);
+    ADM_EXPORT explicit AudioPackFormat(AudioPackFormatName name,
+                                        TypeDescriptor channelType);
     ADM_EXPORT AudioPackFormat(const AudioPackFormat &) = default;
     ADM_EXPORT AudioPackFormat(AudioPackFormat &&) = default;
 
@@ -235,9 +235,9 @@ namespace adm {
       Parameters... optionalNamedArgs) {
     if (channelType == adm::TypeDefinition::HOA) {
       throw std::invalid_argument(
-          "For AudioPackFormat of type HOA use AudioPackFormatHoa::create() instead.");
+          "For AudioPackFormat of type HOA use AudioPackFormatHoa::create() "
+          "instead.");
     } else {
-
       std::shared_ptr<AudioPackFormat> pack(
           new AudioPackFormat(name, channelType));
       detail::setNamedOptionHelper(

--- a/include/adm/elements/audio_pack_format_hoa.hpp
+++ b/include/adm/elements/audio_pack_format_hoa.hpp
@@ -8,132 +8,132 @@
 
 namespace adm {
 
-    class Document;
+  class Document;
 
-    class AudioPackFormatHoa : public AudioPackFormat {
-     public:
-      template <typename... Parameters>
-      static std::shared_ptr<AudioPackFormatHoa> create(
-          AudioPackFormatName name, Parameters... optionalNamedArgs);
-
-      /**
-       * @brief ADM parameter getter template
-       *
-       * Templated getter with the wanted ADM parameter type as template
-       * argument. If currently no value is available trying to get the adm
-       * parameter will result in an exception. Check with the has method before
-       */
-      template <typename Parameter>
-      Parameter get() const;
-
-      /**
-       * @brief ADM parameter has template
-       *
-       * Templated has method with the ADM parameter type as template argument.
-       * Returns true if the ADM parameter is set or has a default value.
-       */
-      template <typename Parameter>
-      bool has() const;
-
-      /**
-       * @brief ADM parameter isDefault template
-       *
-       * Templated isDefault method with the ADM parameter type as template
-       * argument. Returns true if the ADM parameter is the default value.
-       */
-      template <typename Parameter>
-      bool isDefault() const;
-
-      /// @brief ScreenRef setter
-      ADM_EXPORT void set(ScreenRef screenRef);
-      /// @brief Normalization setter
-      ADM_EXPORT void set(Normalization normalization);
-      /// @brief nfcRefDistance setter
-      ADM_EXPORT void set(NfcRefDist nfcRefDist);
-
-      /**
-       * @brief ADM parameter unset template
-       *
-       * Templated unset method with the ADM parameter type as template
-       * argument. Removes an ADM parameter if it is optional or resets it to
-       * the default value if there is one.
-       */
-      template <typename Parameter>
-      void unset();
-
-      // ---- Inherited functions ---- //
-      using AudioPackFormat::get;
-      using AudioPackFormat::has;
-      using AudioPackFormat::set;
-      using AudioPackFormat::unset;
-
-      /**
-       * @brief Print overview to ostream
-       */
-      void print(std::ostream &os) const;
-
-     private:
-      friend class AudioPackFormatHoaAttorney;
-
-      ADM_EXPORT AudioPackFormatHoa(AudioPackFormatName name);
-      // ADM_EXPORT AudioPackFormatHoa(const AudioPackFormat &) = default;
-      // ADM_EXPORT AudioPackFormatHoa(AudioPackFormat &&) = default;
-
-      ADM_EXPORT ScreenRef get(detail::ParameterTraits<ScreenRef>::tag) const;
-      ADM_EXPORT Normalization
-          get(detail::ParameterTraits<Normalization>::tag) const;
-      ADM_EXPORT NfcRefDist get(detail::ParameterTraits<NfcRefDist>::tag) const;
-
-      ADM_EXPORT bool has(detail::ParameterTraits<ScreenRef>::tag) const;
-      ADM_EXPORT bool has(detail::ParameterTraits<Normalization>::tag) const;
-      ADM_EXPORT bool has(detail::ParameterTraits<NfcRefDist>::tag) const;
-
-      ADM_EXPORT bool isDefault(detail::ParameterTraits<ScreenRef>::tag) const;
-      ADM_EXPORT bool isDefault(
-          detail::ParameterTraits<Normalization>::tag) const;
-      ADM_EXPORT bool isDefault(detail::ParameterTraits<NfcRefDist>::tag) const;
-
-      ADM_EXPORT void unset(detail::ParameterTraits<ScreenRef>::tag);
-      ADM_EXPORT void unset(detail::ParameterTraits<Normalization>::tag);
-      ADM_EXPORT void unset(detail::ParameterTraits<NfcRefDist>::tag);
-
-      boost::optional<ScreenRef> screenRef_;
-      boost::optional<Normalization> normalization_;
-      boost::optional<NfcRefDist> nfcRefDist_;
-    };
-
-    // ---- Implementation ---- //
+  class AudioPackFormatHoa : public AudioPackFormat {
+   public:
     template <typename... Parameters>
-    std::shared_ptr<AudioPackFormatHoa> AudioPackFormatHoa::create(
-        AudioPackFormatName name, Parameters... optionalNamedArgs) {
-      std::shared_ptr<AudioPackFormatHoa> pack(new AudioPackFormatHoa(name));
-      detail::setNamedOptionHelper(
-          pack, std::forward<Parameters>(optionalNamedArgs)...);
-      return pack;
-    }
+    static std::shared_ptr<AudioPackFormatHoa> create(
+        AudioPackFormatName name, Parameters... optionalNamedArgs);
 
+    /**
+     * @brief ADM parameter getter template
+     *
+     * Templated getter with the wanted ADM parameter type as template
+     * argument. If currently no value is available trying to get the adm
+     * parameter will result in an exception. Check with the has method before
+     */
     template <typename Parameter>
-    Parameter AudioPackFormatHoa::get() const {
-      typedef typename detail::ParameterTraits<Parameter>::tag Tag;
-      return get(Tag());
-    }
+    Parameter get() const;
 
+    /**
+     * @brief ADM parameter has template
+     *
+     * Templated has method with the ADM parameter type as template argument.
+     * Returns true if the ADM parameter is set or has a default value.
+     */
     template <typename Parameter>
-    bool AudioPackFormatHoa::has() const {
-      typedef typename detail::ParameterTraits<Parameter>::tag Tag;
-      return has(Tag());
-    }
+    bool has() const;
 
+    /**
+     * @brief ADM parameter isDefault template
+     *
+     * Templated isDefault method with the ADM parameter type as template
+     * argument. Returns true if the ADM parameter is the default value.
+     */
     template <typename Parameter>
-    bool AudioPackFormatHoa::isDefault() const {
-      typedef typename detail::ParameterTraits<Parameter>::tag Tag;
-      return isDefault(Tag());
-    }
+    bool isDefault() const;
 
+    /// @brief ScreenRef setter
+    ADM_EXPORT void set(ScreenRef screenRef);
+    /// @brief Normalization setter
+    ADM_EXPORT void set(Normalization normalization);
+    /// @brief nfcRefDistance setter
+    ADM_EXPORT void set(NfcRefDist nfcRefDist);
+
+    /**
+     * @brief ADM parameter unset template
+     *
+     * Templated unset method with the ADM parameter type as template
+     * argument. Removes an ADM parameter if it is optional or resets it to
+     * the default value if there is one.
+     */
     template <typename Parameter>
-    void AudioPackFormatHoa::unset() {
-      typedef typename detail::ParameterTraits<Parameter>::tag Tag;
-      return unset(Tag());
-    }
+    void unset();
+
+    // ---- Inherited functions ---- //
+    using AudioPackFormat::get;
+    using AudioPackFormat::has;
+    using AudioPackFormat::set;
+    using AudioPackFormat::unset;
+
+    /**
+     * @brief Print overview to ostream
+     */
+    void print(std::ostream &os) const;
+
+   private:
+    friend class AudioPackFormatHoaAttorney;
+
+    ADM_EXPORT explicit AudioPackFormatHoa(AudioPackFormatName name);
+    // ADM_EXPORT AudioPackFormatHoa(const AudioPackFormat &) = default;
+    // ADM_EXPORT AudioPackFormatHoa(AudioPackFormat &&) = default;
+
+    ADM_EXPORT ScreenRef get(detail::ParameterTraits<ScreenRef>::tag) const;
+    ADM_EXPORT Normalization
+        get(detail::ParameterTraits<Normalization>::tag) const;
+    ADM_EXPORT NfcRefDist get(detail::ParameterTraits<NfcRefDist>::tag) const;
+
+    ADM_EXPORT bool has(detail::ParameterTraits<ScreenRef>::tag) const;
+    ADM_EXPORT bool has(detail::ParameterTraits<Normalization>::tag) const;
+    ADM_EXPORT bool has(detail::ParameterTraits<NfcRefDist>::tag) const;
+
+    ADM_EXPORT bool isDefault(detail::ParameterTraits<ScreenRef>::tag) const;
+    ADM_EXPORT bool isDefault(
+        detail::ParameterTraits<Normalization>::tag) const;
+    ADM_EXPORT bool isDefault(detail::ParameterTraits<NfcRefDist>::tag) const;
+
+    ADM_EXPORT void unset(detail::ParameterTraits<ScreenRef>::tag);
+    ADM_EXPORT void unset(detail::ParameterTraits<Normalization>::tag);
+    ADM_EXPORT void unset(detail::ParameterTraits<NfcRefDist>::tag);
+
+    boost::optional<ScreenRef> screenRef_;
+    boost::optional<Normalization> normalization_;
+    boost::optional<NfcRefDist> nfcRefDist_;
+  };
+
+  // ---- Implementation ---- //
+  template <typename... Parameters>
+  std::shared_ptr<AudioPackFormatHoa> AudioPackFormatHoa::create(
+      AudioPackFormatName name, Parameters... optionalNamedArgs) {
+    std::shared_ptr<AudioPackFormatHoa> pack(new AudioPackFormatHoa(name));
+    detail::setNamedOptionHelper(
+        pack, std::forward<Parameters>(optionalNamedArgs)...);
+    return pack;
+  }
+
+  template <typename Parameter>
+  Parameter AudioPackFormatHoa::get() const {
+    typedef typename detail::ParameterTraits<Parameter>::tag Tag;
+    return get(Tag());
+  }
+
+  template <typename Parameter>
+  bool AudioPackFormatHoa::has() const {
+    typedef typename detail::ParameterTraits<Parameter>::tag Tag;
+    return has(Tag());
+  }
+
+  template <typename Parameter>
+  bool AudioPackFormatHoa::isDefault() const {
+    typedef typename detail::ParameterTraits<Parameter>::tag Tag;
+    return isDefault(Tag());
+  }
+
+  template <typename Parameter>
+  void AudioPackFormatHoa::unset() {
+    typedef typename detail::ParameterTraits<Parameter>::tag Tag;
+    return unset(Tag());
+  }
 
 }  // namespace adm

--- a/include/adm/elements/audio_pack_format_id.hpp
+++ b/include/adm/elements/audio_pack_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioPackFormatId(Parameters... optionalNamedArgs);
+    explicit AudioPackFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_programme.hpp
+++ b/include/adm/elements/audio_programme.hpp
@@ -180,7 +180,7 @@ namespace adm {
    private:
     friend class AudioProgrammeAttorney;
 
-    ADM_EXPORT AudioProgramme(AudioProgrammeName name);
+    ADM_EXPORT explicit AudioProgramme(AudioProgrammeName name);
     ADM_EXPORT AudioProgramme(const AudioProgramme &) = default;
     ADM_EXPORT AudioProgramme(AudioProgramme &&) = default;
 

--- a/include/adm/elements/audio_programme_id.hpp
+++ b/include/adm/elements/audio_programme_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioProgrammeId(Parameters... optionalNamedArgs);
+    explicit AudioProgrammeId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_stream_format.hpp
+++ b/include/adm/elements/audio_stream_format.hpp
@@ -258,8 +258,8 @@ namespace adm {
    private:
     friend class AudioStreamFormatAttorney;
 
-    ADM_EXPORT AudioStreamFormat(AudioStreamFormatName name,
-                                 FormatDescriptor format);
+    ADM_EXPORT explicit AudioStreamFormat(AudioStreamFormatName name,
+                                          FormatDescriptor format);
     ADM_EXPORT AudioStreamFormat(const AudioStreamFormat &) = default;
     ADM_EXPORT AudioStreamFormat(AudioStreamFormat &&) = default;
 

--- a/include/adm/elements/audio_stream_format_id.hpp
+++ b/include/adm/elements/audio_stream_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioStreamFormatId(Parameters... optionalNamedArgs);
+    explicit AudioStreamFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_track_format.hpp
+++ b/include/adm/elements/audio_track_format.hpp
@@ -182,8 +182,8 @@ namespace adm {
    private:
     friend class AudioTrackFormatAttorney;
 
-    ADM_EXPORT AudioTrackFormat(AudioTrackFormatName name,
-                                FormatDescriptor channelType);
+    ADM_EXPORT explicit AudioTrackFormat(AudioTrackFormatName name,
+                                         FormatDescriptor channelType);
     ADM_EXPORT AudioTrackFormat(const AudioTrackFormat &) = default;
     ADM_EXPORT AudioTrackFormat(AudioTrackFormat &&) = default;
 

--- a/include/adm/elements/audio_track_format_id.hpp
+++ b/include/adm/elements/audio_track_format_id.hpp
@@ -36,7 +36,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioTrackFormatId(Parameters... optionalNamedArgs);
+    explicit AudioTrackFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_track_uid_id.hpp
+++ b/include/adm/elements/audio_track_uid_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioTrackUidId(Parameters... optionalNamedArgs);
+    explicit AudioTrackUidId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/channel_lock.hpp
+++ b/include/adm/elements/channel_lock.hpp
@@ -39,7 +39,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ChannelLock(Parameters... optionalNamedArgs);
+    explicit ChannelLock(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/frequency.hpp
+++ b/include/adm/elements/frequency.hpp
@@ -51,7 +51,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    Frequency(Parameters... optionalNamedArgs);
+    explicit Frequency(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/gain_interaction_range.hpp
+++ b/include/adm/elements/gain_interaction_range.hpp
@@ -50,7 +50,7 @@ namespace adm {
      * in random order.
      */
     template <typename... Parameters>
-    GainInteractionRange(Parameters... optionalNamedArgs);
+    explicit GainInteractionRange(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/jump_position.hpp
+++ b/include/adm/elements/jump_position.hpp
@@ -35,7 +35,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    JumpPosition(Parameters... optionalNamedArgs);
+    explicit JumpPosition(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/loudness_metadata.hpp
+++ b/include/adm/elements/loudness_metadata.hpp
@@ -61,7 +61,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    LoudnessMetadata(Parameters... optionalNamedArgs);
+    explicit LoudnessMetadata(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/object_divergence.hpp
+++ b/include/adm/elements/object_divergence.hpp
@@ -54,7 +54,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ObjectDivergence(Parameters... optionalNamedArgs);
+    explicit ObjectDivergence(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/position.hpp
+++ b/include/adm/elements/position.hpp
@@ -25,8 +25,8 @@ namespace adm {
     typedef SphericalPositionTag tag;
 
     /// @brief Constructor without optional parameters
-    ADM_EXPORT SphericalPosition(Azimuth azimuth = Azimuth(0.f),
-                                 Elevation elevation = Elevation(0.f));
+    ADM_EXPORT explicit SphericalPosition(Azimuth azimuth = Azimuth(0.f),
+                                          Elevation elevation = Elevation(0.f));
     /**
      * @brief Constructor template
      *
@@ -34,8 +34,8 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    SphericalPosition(Azimuth azimuth, Elevation elevation,
-                      Parameters... optionalNamedArgs);
+    explicit SphericalPosition(Azimuth azimuth, Elevation elevation,
+                               Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/position_interaction_range.hpp
+++ b/include/adm/elements/position_interaction_range.hpp
@@ -107,7 +107,7 @@ namespace adm {
      * in random order.
      */
     template <typename... Parameters>
-    PositionInteractionRange(Parameters... optionalNamedArgs);
+    explicit PositionInteractionRange(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/screen_edge_lock.hpp
+++ b/include/adm/elements/screen_edge_lock.hpp
@@ -52,7 +52,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ScreenEdgeLock(Parameters... optionalNamedArgs);
+    explicit ScreenEdgeLock(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/speaker_position.hpp
+++ b/include/adm/elements/speaker_position.hpp
@@ -38,7 +38,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    SpeakerPosition(Parameters... optionalNamedArgs);
+    explicit SpeakerPosition(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template


### PR DESCRIPTION
this should avoid problems as in issue #47 