### PR TITLE
include <algorithm> where it's used

### DIFF
--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -1,6 +1,7 @@
 /// @file audio_channel_format.hpp
 #pragma once
 
+#include <algorithm>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <memory>

--- a/include/adm/helper/element_range.hpp
+++ b/include/adm/helper/element_range.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 

--- a/include/adm/utilities/comparator.hpp
+++ b/include/adm/utilities/comparator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include "adm/elements/time.hpp"
 
 namespace adm {

--- a/include/adm/utilities/lookup.hpp
+++ b/include/adm/utilities/lookup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 #include "adm/document.hpp"

--- a/src/elements/audio_block_format_direct_speakers.cpp
+++ b/src/elements/audio_block_format_direct_speakers.cpp
@@ -1,5 +1,7 @@
 #include "adm/elements/audio_block_format_direct_speakers.hpp"
 
+#include <algorithm>
+
 namespace adm {
 
   namespace {

--- a/src/elements/audio_object.cpp
+++ b/src/elements/audio_object.cpp
@@ -6,6 +6,8 @@
 #include "adm/utilities/id_assignment.hpp"
 #include "adm/errors.hpp"
 
+#include <algorithm>
+
 namespace adm {
 
   // ---- Defaults ---- //

--- a/src/elements/audio_pack_format.cpp
+++ b/src/elements/audio_pack_format.cpp
@@ -5,6 +5,7 @@
 #include "adm/utilities/element_io.hpp"
 #include "adm/utilities/id_assignment.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 namespace adm {

--- a/src/elements/audio_programme.cpp
+++ b/src/elements/audio_programme.cpp
@@ -9,6 +9,8 @@
 #include "adm/utilities/element_io.hpp"
 #include "adm/utilities/id_assignment.hpp"
 
+#include <algorithm>
+
 namespace adm {
 
   // ---- Defaults ---- //

--- a/src/elements/audio_stream_format.cpp
+++ b/src/elements/audio_stream_format.cpp
@@ -5,6 +5,8 @@
 #include "adm/utilities/element_io.hpp"
 #include "adm/utilities/id_assignment.hpp"
 
+#include <algorithm>
+
 namespace adm {
 
   // ---- Getter ---- //

--- a/tests/audio_channel_format_tests.cpp
+++ b/tests/audio_channel_format_tests.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+#include <algorithm>
 #include <catch2/catch.hpp>
 #include "adm/elements/audio_channel_format.hpp"
 #include "adm/utilities/comparator.hpp"


### PR DESCRIPTION
This is mostly for `std::find`. I only had an issue in
`audio_block_format_direct_speakers.cpp`, but it's worth fixing
everywhere.