### PR TITLE
Add AudioObjects without using the incomplete hard-coded Lookup-Tables

### DIFF
--- a/include/adm/utilities/object_creation.hpp
+++ b/include/adm/utilities/object_creation.hpp
@@ -87,4 +87,29 @@ namespace adm {
                                      const std::string& name,
                                      const std::string& speakerLayout);
 
+  /**
+   * @brief Create and add `AudioObject` with common definitions direct speakers
+   * channel bed to document
+   *
+   * Creates an `AudioObject` and corresponding `AudioTrackUids` and connects it
+   * to the common definition ADM elements for the given speaker layout. The
+   * created ADM elements are added to the given document.
+   *
+   * @note The document must already have the common definition elements added.
+   *
+   * @param document The document where the `AudioObject` and the
+   * `AudioTrackUids` should be added to and whose common definition ADM
+   * elements should be used.
+   * @param name Name that will be used for the created `AudioObject`.
+   * @param packFormatId AudioPackFormatId of the given layout.
+   * @param trackFormatIds AudioTrackFormatIds of all the speakers in the layout.
+   * @param speakerLabels Labels of all the speakers in the layout.
+   */
+  ADM_EXPORT SimpleCommonDefinitionsObjectHolder
+      addSimpleCommonDefinitionsObjectTo(std::shared_ptr<Document> document,
+          const std::string& name,
+          const std::string& packFormatId,
+          const std::vector<std::string>& trackFormatIds,
+          const std::vector<std::string>& speakerLabels);
+
 }  // namespace adm

--- a/src/utilities/object_creation.cpp
+++ b/src/utilities/object_creation.cpp
@@ -71,4 +71,39 @@ namespace adm {
     document->add(holder.audioObject);
     return holder;
   }
+
+  SimpleCommonDefinitionsObjectHolder addSimpleCommonDefinitionsObjectTo(
+      std::shared_ptr<Document> document, const std::string& name,
+      const std::string& packFormatId,
+      const std::vector<std::string>& trackFormatIds,
+      const std::vector<std::string>& speakerLabels) {
+      SimpleCommonDefinitionsObjectHolder holder;
+      holder.audioObject = AudioObject::create(AudioObjectName(name));
+      auto packFormat =
+          document->lookup(adm::parseAudioPackFormatId(packFormatId));
+      if (!packFormat) {
+          std::stringstream ss;
+          ss << "AudioPackFormatId \"" << packFormatId
+              << "\" not found. Are the common definitions added to the document?";
+          throw error::AdmException(ss.str());
+      }
+      holder.audioObject->addReference(packFormat);
+      if (trackFormatIds.size() != speakerLabels.size()) {
+          std::stringstream ss;
+          ss << "Sizes of trackFormatIds and speakerLabels arguments do not match.";
+          throw error::AdmException(ss.str());
+      }
+      for (size_t i = 0; i < trackFormatIds.size(); i++) {
+          auto track =
+              document->lookup(adm::parseAudioTrackFormatId(trackFormatIds.at(i)));
+          auto uid = AudioTrackUid::create();
+          uid->setReference(packFormat);
+          uid->setReference(track);
+          holder.audioObject->addReference(uid);
+          holder.audioTrackUids[speakerLabels.at(i)] = uid;
+      }
+      document->add(holder.audioObject);
+      return holder;
+  }
+
 }  // namespace adm


### PR DESCRIPTION
Because the libadm [lookup-tables](https://github.com/ebu/libadm/blob/master/src/common_definitions.cpp) are incomplete, this pull request extends object_creation.hpp/cpp by a function to add AudioObjects directly using AudioTrack/AudioPackFormatIds.
This is needed for the [ ear-production-suite](https://github.com/ebu/ear-production-suite) direct speakers support of additional layouts beside from the ones specified in BS.2051.