### PR TITLE
Fix segfault when there's no root node

### DIFF
--- a/include/adm/private/rapidxml_utils.hpp
+++ b/include/adm/private/rapidxml_utils.hpp
@@ -10,10 +10,10 @@ namespace adm {
       return std::count(begin, end, '\n');
     }
 
-    int getDocumentLine(rapidxml::xml_node<>* node) {
+    inline int getDocumentLine(rapidxml::xml_node<>* node) {
       return countLines(node->document()->first_node()->name(), node->name());
     }
-    int getDocumentLine(rapidxml::xml_attribute<>* attr) {
+    inline int getDocumentLine(rapidxml::xml_attribute<>* attr) {
       return countLines(attr->document()->first_node()->name(), attr->name());
     }
   }  // namespace xml

--- a/src/private/xml_parser.cpp
+++ b/src/private/xml_parser.cpp
@@ -77,7 +77,7 @@ namespace adm {
         resolveReference(streamFormatPackFormatRef_);
         resolveReferences(streamFormatTrackFormatRefs_);
       } else {
-        throw std::runtime_error("audioFormatExtended node not found");
+        throw error::XmlParsingError("audioFormatExtended node not found");
       }
       return document_;
     }  // namespace xml
@@ -724,7 +724,7 @@ namespace adm {
         return ContentKind(
             parseAttribute<MixedContentKind>(node, "mixedContentKind"));
       } else {
-        throw std::runtime_error("unknown dialogue id");
+        throw error::XmlParsingError("unknown dialogue id", getDocumentLine(node));
       }
     }
 

--- a/src/private/xml_parser.cpp
+++ b/src/private/xml_parser.cpp
@@ -30,6 +30,10 @@ namespace adm {
     std::shared_ptr<Document> XmlParser::parse() {
       rapidxml::xml_document<> xmlDocument;
       xmlDocument.parse<0>(xmlFile_.data());
+
+      if (!xmlDocument.first_node())
+        throw error::XmlParsingError("xml document is empty");
+
       NodePtr root = nullptr;
       if (isSet(options_, ParserOptions::recursive_node_search)) {
         root =

--- a/tests/xml_parser_tests.cpp
+++ b/tests/xml_parser_tests.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch.hpp>
 #include "adm/private/rapidxml_utils.hpp"
 #include "adm/private/rapidxml_wrapper.hpp"
+#include "adm/errors.hpp"
+#include "adm/parse.hpp"
 
 TEST_CASE("line_number_calculation") {
   using namespace adm;
@@ -25,5 +27,21 @@ TEST_CASE("line_number_calculation") {
     REQUIRE(p == 2);
     p = adm::xml::getDocumentLine(freq->first_attribute());
     REQUIRE(p == 3);
+  }
+}
+
+TEST_CASE("empty document") {
+  using namespace adm;
+
+  SECTION("ebucore") {
+    std::istringstream admStream("");
+    REQUIRE_THROWS_AS(parseXml(admStream), error::XmlParsingError);
+  }
+
+  SECTION("recursive") {
+    std::istringstream admStream("");
+    REQUIRE_THROWS_AS(
+        parseXml(admStream, xml::ParserOptions::recursive_node_search),
+        error::XmlParsingError);
   }
 }


### PR DESCRIPTION
previously this caused a segfault; a separate exception string is used as accidentally parsing an empty document seems like a reasonably common mistake

`inline` changes weren't necessary in the end, but it's a good idea anyway