### PR TITLE
Add automatic base class generation

### DIFF
--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -1,0 +1,169 @@
+#pragma once
+#include "adm/detail/auto_base_detail.hpp"
+#include "adm/detail/type_traits.hpp"
+#include "adm/export.h"
+#include "boost/optional.hpp"
+
+namespace adm {
+  namespace detail {
+    // libadm elements typically have some overloaded methods corresponding to
+    // each parameter. The set of methods defined depends on the behaviour of
+    // the parameter, so for example only optional parameters have isDefault
+    // and unset methods.
+    //
+    // We define some classes below like RequiredParameter and DefaultParameter
+    // which define these methods automatically for given parameter types. To
+    // use these, they need to be combined together in such a way that all the
+    // methods for all the parameters we want to define are available in one
+    // overload set.
+    //
+    // This is done using multiple inheritance: given a set of *Base classes,
+    // we can make a derived class using HasParameters which inherits from all
+    // of them.
+    //
+    // The problem this presents is that the derived class needs a using
+    // declaration pointing to each method in the base classes, in order to
+    // bring them into one overload set, but we can't have a using declaration
+    // which points to a method which doesn't exist.
+    //
+    // To make this work, each *Base class defines some flags (defined in
+    // Flags) which says which sets of methods it implements. When Combine is
+    // used to combine two *Base classes together, these flags are or-ed in the
+    // resulting class, and the correct specialisations of the Combine* classes
+    // are selected by and-ing the flags (we only need the using declarations
+    // if both bases have the methods defined).
+    //
+    // To enable all combinations without making the dreaded diamond, these are
+    // chained, with the actual inheritance happening in CombineRaw. When
+    // combining A and B we have an inheritance hierarchy like:
+    //
+    // Combine<A, B>
+    //  -> ApplyIf<CombineGetSetHas<A, B>, X>
+    //      -> ApplyIf<CombineIsDefaultUnset<A, B>, Y>
+    //          -> CombineRaw<A, B>
+    //              -> A
+    //              -> B
+    //
+    // where X and Y are the flags controlling whether Combine* is applied or
+    // not.
+    //
+    // Combine is used by HasParameters, which recursively combines many *Base
+    // classes.
+
+    struct Flags {
+      static constexpr bool has_get_set_has = false;
+      static constexpr bool has_isDefault_unset = false;
+    };
+
+    /// a subclass of Base, with using declarations for set, get and has in A
+    /// and B
+    template <typename A, typename B, typename Base>
+    struct CombineGetSetHas : public Base {
+      using A::get;
+      using B::get;
+
+      using A::set;
+      using B::set;
+
+      using A::has;
+      using B::has;
+    };
+
+    /// a subclass of Base, with using declarations for isDefault and unset in A
+    /// and B
+    template <typename A, typename B, typename Base>
+    struct CombineIsDefaultUnset : public Base {
+      using A::isDefault;
+      using B::isDefault;
+
+      using A::unset;
+      using B::unset;
+    };
+
+    /// a subclass of A and B, with methods according to their Flags
+    template <typename A, typename B>
+    struct Combine
+        : public ApplyIf<
+              A::has_get_set_has && B::has_get_set_has, CombineGetSetHas, A, B,
+              ApplyIf<A::has_isDefault_unset && B::has_isDefault_unset,
+                      CombineIsDefaultUnset, A, B, CombineRaw<A, B>>> {
+      static constexpr bool has_get_set_has =
+          A::has_get_set_has || B::has_get_set_has;
+      static constexpr bool has_isDefault_unset =
+          A::has_isDefault_unset || B::has_isDefault_unset;
+    };
+
+    /// make a class derived from the given base classes, combining the
+    /// get, set, has, isDefault and unset overloads
+    template <typename B, typename... BTail>
+    struct HasParameters : public Combine<B, HasParameters<BTail...>> {};
+
+    template <typename B>
+    struct HasParameters<B> : public B {};
+
+    /// Get the default value of T parameters. Specialise this to add custom
+    /// defaults.
+    template <typename T>
+    T getDefault() {
+      return T{};
+    }
+
+    /// base class with set/get/has methods for a required parameter of type T
+    /// combine these together using HasParameters
+    template <typename T,
+              typename Tag = typename detail::ParameterTraits<T>::tag>
+    class RequiredParameter : public Flags {
+     public:
+      static constexpr bool has_get_set_has = true;
+
+      ADM_EXPORT T get(Tag) const { return value_; }
+      ADM_EXPORT void set(T value) { value_ = value; }
+      ADM_EXPORT bool has(Tag) const { return true; }
+
+     private:
+      T value_;
+    };
+
+    /// base class with set/get/has/isDefault/unset methods for an optional
+    /// parameter of type T with no default. combine these together using
+    /// HasParameters
+    template <typename T,
+              typename Tag = typename detail::ParameterTraits<T>::tag>
+    class OptionalParameter : public Flags {
+     public:
+      static constexpr bool has_get_set_has = true;
+      static constexpr bool has_isDefault_unset = true;
+
+      ADM_EXPORT T get(Tag) const { return value_.get(); }
+      ADM_EXPORT void set(T value) { value_ = value; }
+      ADM_EXPORT bool has(Tag) const { return value_ != boost::none; }
+      ADM_EXPORT bool isDefault(Tag) const { return false; }
+      ADM_EXPORT void unset(Tag) { value_ = boost::none; }
+
+     private:
+      boost::optional<T> value_;
+    };
+
+    /// base class with set/get/has/isDefault/unset methods for an optional
+    /// parameter of type T, which has a default provided by DefaultParameter.
+    /// combine these together using HasParameters
+    template <typename T,
+              typename Tag = typename detail::ParameterTraits<T>::tag>
+    class DefaultParameter : public Flags {
+     public:
+      static constexpr bool has_get_set_has = true;
+      static constexpr bool has_isDefault_unset = true;
+
+      ADM_EXPORT T get(Tag) const {
+        return boost::get_optional_value_or(value_, getDefault<T>());
+      }
+      ADM_EXPORT void set(T value) { value_ = value; }
+      ADM_EXPORT bool has(Tag) const { return true; }
+      ADM_EXPORT bool isDefault(Tag) const { return value_ == boost::none; }
+      ADM_EXPORT void unset(Tag) { value_ = boost::none; }
+
+     private:
+      boost::optional<T> value_;
+    };
+  }  // namespace detail
+}  // namespace adm

--- a/include/adm/detail/auto_base_detail.hpp
+++ b/include/adm/detail/auto_base_detail.hpp
@@ -1,0 +1,31 @@
+
+namespace adm {
+  namespace detail {
+    /// Combine A and B using F is defined_in_both
+    template <bool defined_in_both,
+              template <typename A, typename B, typename Base> class F,
+              typename A, typename B, typename Base>
+    struct ApplyIfT;
+
+    template <template <typename A, typename B, typename Base> class F,
+              typename A, typename B, typename Base>
+    struct ApplyIfT<false, F, A, B, Base> {
+      using type = Base;
+    };
+
+    template <template <typename A, typename B, typename Base> class F,
+              typename A, typename B, typename Base>
+    struct ApplyIfT<true, F, A, B, Base> {
+      using type = F<A, B, Base>;
+    };
+
+    template <bool defined_in_both,
+              template <typename A, typename B, typename Base> class F,
+              typename A, typename B, typename Base>
+    using ApplyIf = typename ApplyIfT<defined_in_both, F, A, B, Base>::type;
+
+    /// subclass of A and B
+    template <typename A, typename B>
+    struct CombineRaw : public A, public B {};
+  }  // namespace detail
+}  // namespace adm

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -2,14 +2,14 @@
 #pragma once
 
 #include <boost/optional.hpp>
-#include "adm/elements/time.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
 #include "adm/elements/channel_lock.hpp"
-#include "adm/elements/importance.hpp"
 #include "adm/elements/jump_position.hpp"
 #include "adm/elements/object_divergence.hpp"
 #include "adm/elements/position.hpp"
+#include "adm/elements/private/common_parameters.hpp"
 #include "adm/elements_fwd.hpp"
+#include "adm/detail/auto_base.hpp"
 #include "adm/detail/named_option_helper.hpp"
 #include "adm/detail/named_type.hpp"
 #include "adm/export.h"
@@ -35,10 +35,6 @@ namespace adm {
   struct DepthTag {};
   /// @brief NamedType for depth parameter
   using Depth = detail::NamedType<float, DepthTag>;
-  /// @brief Tag for NamedType ::Gain
-  struct GainTag {};
-  /// @brief NamedType for gain parameter
-  using Gain = detail::NamedType<float, GainTag>;
   /// @brief Tag for NamedType ::Diffuse
   struct DiffuseTag {};
   /// @brief NamedType for diffuse parameter
@@ -47,6 +43,23 @@ namespace adm {
 
   /// @brief Tag for AudioBlockFormatObjects
   struct AudioBlockFormatObjectsTag {};
+
+  namespace detail {
+    extern template class ADM_EXPORT_TEMPLATE_METHODS
+        RequiredParameter<AudioBlockFormatId>;
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Width>;
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Height>;
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Depth>;
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Diffuse>;
+
+    using AudioBlockFormatObjectsBase =
+        HasParameters<RequiredParameter<AudioBlockFormatId>,
+                      DefaultParameter<Rtime>, OptionalParameter<Duration>,
+                      DefaultParameter<Width>, DefaultParameter<Height>,
+                      DefaultParameter<Depth>, DefaultParameter<Diffuse>,
+                      DefaultParameter<Gain>, DefaultParameter<Importance>>;
+  }  // namespace detail
+
   /**
    * @brief Class representation for ADM element audioBlockFormat if
    * audioChannelFormat.typeDefinition == "Objects"
@@ -54,7 +67,7 @@ namespace adm {
    * @warning This class has unsupported parameters
    *   - ZoneExclusion
    */
-  class AudioBlockFormatObjects {
+  class AudioBlockFormatObjects : private detail::AudioBlockFormatObjectsBase {
    public:
     typedef AudioBlockFormatObjectsTag tag;
     /// Type that holds the id for this element;
@@ -102,12 +115,7 @@ namespace adm {
     template <typename Parameter>
     bool isDefault() const;
 
-    /// @brief AudioBlockFormatId setter
-    ADM_EXPORT void set(AudioBlockFormatId id);
-    /// @brief Rtime setter
-    ADM_EXPORT void set(Rtime rtime);
-    /// @brief Duration setter
-    ADM_EXPORT void set(Duration duration);
+    using detail::AudioBlockFormatObjectsBase::set;
 
     /**
      * @brief Cartesian setter
@@ -141,18 +149,8 @@ namespace adm {
      * SphericalPosition. Also the Cartesian flag will be set automatically.
      */
     ADM_EXPORT void set(CartesianPosition position);
-    /// @brief Width setter
-    ADM_EXPORT void set(Width width);
-    /// @brief Height setter
-    ADM_EXPORT void set(Height height);
-    /// @brief Depth setter
-    ADM_EXPORT void set(Depth depth);
     /// @brief ScreenEdgeLock setter
     ADM_EXPORT void set(ScreenEdgeLock screenEdgeLock);
-    /// @brief Gain setter
-    ADM_EXPORT void set(Gain gain);
-    /// @brief Diffuse setter
-    ADM_EXPORT void set(Diffuse diffuse);
     /// @brief ChannelLock setter
     ADM_EXPORT void set(ChannelLock channelLock);
     /// @brief ObjectDivergence setter
@@ -161,8 +159,6 @@ namespace adm {
     ADM_EXPORT void set(JumpPosition jumpPosition);
     /// @brief ScreenRef setter
     ADM_EXPORT void set(ScreenRef screenRef);
-    /// @brief Importance setter
-    ADM_EXPORT void set(Importance importance);
 
     /**
      * @brief ADM parameter unset template
@@ -175,103 +171,65 @@ namespace adm {
     void unset();
 
    private:
-    ADM_EXPORT AudioBlockFormatId
-        get(detail::ParameterTraits<AudioBlockFormatId>::tag) const;
-    ADM_EXPORT Rtime get(detail::ParameterTraits<Rtime>::tag) const;
-    ADM_EXPORT Duration get(detail::ParameterTraits<Duration>::tag) const;
+    using detail::AudioBlockFormatObjectsBase::get;
+    using detail::AudioBlockFormatObjectsBase::has;
+    using detail::AudioBlockFormatObjectsBase::isDefault;
+    using detail::AudioBlockFormatObjectsBase::unset;
+
     ADM_EXPORT Cartesian get(detail::ParameterTraits<Cartesian>::tag) const;
     ADM_EXPORT Position get(detail::ParameterTraits<Position>::tag) const;
     ADM_EXPORT SphericalPosition
         get(detail::ParameterTraits<SphericalPosition>::tag) const;
     ADM_EXPORT CartesianPosition
         get(detail::ParameterTraits<CartesianPosition>::tag) const;
-    ADM_EXPORT Width get(detail::ParameterTraits<Width>::tag) const;
-    ADM_EXPORT Height get(detail::ParameterTraits<Height>::tag) const;
-    ADM_EXPORT Depth get(detail::ParameterTraits<Depth>::tag) const;
     ADM_EXPORT ScreenEdgeLock
         get(detail::ParameterTraits<ScreenEdgeLock>::tag) const;
-    ADM_EXPORT Gain get(detail::ParameterTraits<Gain>::tag) const;
-    ADM_EXPORT Diffuse get(detail::ParameterTraits<Diffuse>::tag) const;
     ADM_EXPORT ChannelLock get(detail::ParameterTraits<ChannelLock>::tag) const;
     ADM_EXPORT ObjectDivergence
         get(detail::ParameterTraits<ObjectDivergence>::tag) const;
     ADM_EXPORT JumpPosition
         get(detail::ParameterTraits<JumpPosition>::tag) const;
     ADM_EXPORT ScreenRef get(detail::ParameterTraits<ScreenRef>::tag) const;
-    ADM_EXPORT Importance get(detail::ParameterTraits<Importance>::tag) const;
 
-    ADM_EXPORT bool has(detail::ParameterTraits<AudioBlockFormatId>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Rtime>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Duration>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<Cartesian>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<Position>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<SphericalPosition>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<CartesianPosition>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Width>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Height>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Depth>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<ScreenEdgeLock>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Gain>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Diffuse>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<ChannelLock>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<ObjectDivergence>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<JumpPosition>::tag) const;
     ADM_EXPORT bool has(detail::ParameterTraits<ScreenRef>::tag) const;
-    ADM_EXPORT bool has(detail::ParameterTraits<Importance>::tag) const;
 
     template <typename Tag>
     bool isDefault(Tag) const {
       return false;
     }
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Rtime>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<Cartesian>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Width>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Height>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Depth>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Gain>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Diffuse>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<ChannelLock>::tag) const;
     ADM_EXPORT bool isDefault(
         detail::ParameterTraits<ObjectDivergence>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<JumpPosition>::tag) const;
     ADM_EXPORT bool isDefault(detail::ParameterTraits<ScreenRef>::tag) const;
-    ADM_EXPORT bool isDefault(detail::ParameterTraits<Importance>::tag) const;
 
-    ADM_EXPORT void unset(detail::ParameterTraits<Rtime>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Duration>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<Cartesian>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<Position>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<SphericalPosition>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<CartesianPosition>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Width>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Height>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Depth>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<ScreenEdgeLock>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Gain>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Diffuse>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<ChannelLock>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<ObjectDivergence>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<JumpPosition>::tag);
     ADM_EXPORT void unset(detail::ParameterTraits<ScreenRef>::tag);
-    ADM_EXPORT void unset(detail::ParameterTraits<Importance>::tag);
 
-    AudioBlockFormatId id_;
-    boost::optional<Rtime> rtime_;
-    boost::optional<Duration> duration_;
     boost::optional<Cartesian> cartesian_;
     boost::optional<SphericalPosition> sphericalPosition_;
     boost::optional<CartesianPosition> cartesianPosition_;
-    boost::optional<Height> height_;
-    boost::optional<Width> width_;
-    boost::optional<Depth> depth_;
     boost::optional<ScreenEdgeLock> screenEdgeLock_;
-    boost::optional<Gain> gain_;
-    boost::optional<Diffuse> diffuse_;
     boost::optional<ChannelLock> channelLock_;
     boost::optional<ObjectDivergence> objectDivergence_;
     boost::optional<JumpPosition> jumpPosition_;
     boost::optional<ScreenRef> screenRef_;
-    boost::optional<Importance> importance_;
   };
 
   // ---- Implementation ---- //

--- a/include/adm/elements/private/common_parameters.hpp
+++ b/include/adm/elements/private/common_parameters.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include "adm/detail/auto_base.hpp"
+#include "adm/elements/importance.hpp"
+#include "adm/elements/time.hpp"
+
+namespace adm {
+  /// @brief Tag for NamedType ::Gain
+  struct GainTag {};
+  /// @brief NamedType for gain parameter
+  using Gain = detail::NamedType<float, GainTag>;
+
+  namespace detail {
+    template <>
+    inline Importance getDefault<Importance>() {
+      return Importance{10};
+    }
+
+    template <>
+    inline Gain getDefault<Gain>() {
+      return Gain{1.0f};
+    }
+
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Gain>;
+
+    extern template class ADM_EXPORT_TEMPLATE_METHODS
+        DefaultParameter<Importance>;
+
+    extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Rtime>;
+    extern template class ADM_EXPORT_TEMPLATE_METHODS
+        OptionalParameter<Duration>;
+  }  // namespace detail
+}  // namespace adm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,8 +108,20 @@ endif()
 set_target_properties(adm PROPERTIES CXX_EXTENSIONS OFF)
 
 include(GenerateExportHeader)
+set(EXPORT_EXTRA_CONTENT
+    "
+// use on an extern class template instantiation to force exporting of methods;
+// not required on MSVC where exported methods of explicitly instantiated class
+// templates are actually exported
+#ifdef _MSC_VER
+#define ADM_EXPORT_TEMPLATE_METHODS
+#else
+#define ADM_EXPORT_TEMPLATE_METHODS ADM_EXPORT
+#endif
+")
 generate_export_header(adm
   EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/adm/export.h
+  CUSTOM_CONTENT_FROM_VARIABLE EXPORT_EXTRA_CONTENT
 )
 
 ############################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(adm
   elements/audio_block_format_binaural.cpp
   elements/audio_object_interaction.cpp
   elements/audio_pack_format_hoa.cpp
+  elements/common_parameters.cpp
   elements/time.cpp
   elements/channel_lock.cpp
   elements/frequency.cpp

--- a/src/elements/audio_block_format_objects.cpp
+++ b/src/elements/audio_block_format_objects.cpp
@@ -4,32 +4,21 @@ namespace adm {
 
   // ---- Defaults ---- //
   namespace {
-    const Rtime rtimeDefault{std::chrono::seconds(0)};
-    const Width widthDefault{0.f};
-    const Height heightDefault{0.f};
-    const Depth depthDefault{0.f};
-    const Gain gainDefault{1.f};
-    const Diffuse diffuseDefault{0.f};
     const ChannelLock channelLockDefault{};
     const ObjectDivergence objectDivergenceDefault{};
     const JumpPosition jumpPositionDefault{};
     const ScreenRef screenRefDefault{false};
-    const Importance importanceDefault{10};
   }  // namespace
 
+  namespace detail {
+    template class RequiredParameter<AudioBlockFormatId>;
+    template class DefaultParameter<Width>;
+    template class DefaultParameter<Height>;
+    template class DefaultParameter<Depth>;
+    template class DefaultParameter<Diffuse>;
+  }  // namespace detail
+
   // ---- Getter ---- //
-  AudioBlockFormatId AudioBlockFormatObjects::get(
-      detail::ParameterTraits<AudioBlockFormatId>::tag) const {
-    return id_;
-  }
-  Rtime AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Rtime>::tag) const {
-    return boost::get_optional_value_or(rtime_, rtimeDefault);
-  }
-  Duration AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Duration>::tag) const {
-    return duration_.get();
-  }
   Cartesian AudioBlockFormatObjects::get(
       detail::ParameterTraits<Cartesian>::tag) const {
     if (cartesian_ != boost::none) {
@@ -58,28 +47,9 @@ namespace adm {
       detail::ParameterTraits<CartesianPosition>::tag) const {
     return cartesianPosition_.get();
   }
-  Width AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Width>::tag) const {
-    return boost::get_optional_value_or(width_, widthDefault);
-  }
-  Height AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Height>::tag) const {
-    return boost::get_optional_value_or(height_, heightDefault);
-  }
-  Depth AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Depth>::tag) const {
-    return boost::get_optional_value_or(depth_, depthDefault);
-  }
   ScreenEdgeLock AudioBlockFormatObjects::get(
       detail::ParameterTraits<ScreenEdgeLock>::tag) const {
     return screenEdgeLock_.get();
-  }
-  Gain AudioBlockFormatObjects::get(detail::ParameterTraits<Gain>::tag) const {
-    return boost::get_optional_value_or(gain_, gainDefault);
-  }
-  Diffuse AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Diffuse>::tag) const {
-    return boost::get_optional_value_or(diffuse_, diffuseDefault);
   }
   ChannelLock AudioBlockFormatObjects::get(
       detail::ParameterTraits<ChannelLock>::tag) const {
@@ -98,23 +68,8 @@ namespace adm {
       detail::ParameterTraits<ScreenRef>::tag) const {
     return boost::get_optional_value_or(screenRef_, screenRefDefault);
   }
-  Importance AudioBlockFormatObjects::get(
-      detail::ParameterTraits<Importance>::tag) const {
-    return boost::get_optional_value_or(importance_, importanceDefault);
-  }
 
   // ---- Has ---- //
-  bool AudioBlockFormatObjects::has(
-      detail::ParameterTraits<AudioBlockFormatId>::tag) const {
-    return true;
-  }
-  bool AudioBlockFormatObjects::has(detail::ParameterTraits<Rtime>::tag) const {
-    return true;
-  }
-  bool AudioBlockFormatObjects::has(
-      detail::ParameterTraits<Duration>::tag) const {
-    return duration_ != boost::none;
-  }
   bool AudioBlockFormatObjects::has(
       detail::ParameterTraits<Cartesian>::tag) const {
     return true;
@@ -132,26 +87,9 @@ namespace adm {
       detail::ParameterTraits<CartesianPosition>::tag) const {
     return cartesianPosition_ != boost::none;
   }
-  bool AudioBlockFormatObjects::has(detail::ParameterTraits<Width>::tag) const {
-    return true;
-  }
-  bool AudioBlockFormatObjects::has(
-      detail::ParameterTraits<Height>::tag) const {
-    return true;
-  }
-  bool AudioBlockFormatObjects::has(detail::ParameterTraits<Depth>::tag) const {
-    return true;
-  }
   bool AudioBlockFormatObjects::has(
       detail::ParameterTraits<ScreenEdgeLock>::tag) const {
     return screenEdgeLock_ != boost::none;
-  }
-  bool AudioBlockFormatObjects::has(detail::ParameterTraits<Gain>::tag) const {
-    return true;
-  }
-  bool AudioBlockFormatObjects::has(
-      detail::ParameterTraits<Diffuse>::tag) const {
-    return true;
   }
   bool AudioBlockFormatObjects::has(
       detail::ParameterTraits<ChannelLock>::tag) const {
@@ -169,39 +107,11 @@ namespace adm {
       detail::ParameterTraits<ScreenRef>::tag) const {
     return true;
   }
-  bool AudioBlockFormatObjects::has(
-      detail::ParameterTraits<Importance>::tag) const {
-    return true;
-  }
 
   // ---- isDefault ---- //
   bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Rtime>::tag) const {
-    return rtime_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
       detail::ParameterTraits<Cartesian>::tag) const {
     return cartesian_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Width>::tag) const {
-    return width_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Height>::tag) const {
-    return height_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Depth>::tag) const {
-    return depth_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Gain>::tag) const {
-    return gain_ == boost::none;
-  }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Diffuse>::tag) const {
-    return diffuse_ == boost::none;
   }
   bool AudioBlockFormatObjects::isDefault(
       detail::ParameterTraits<ChannelLock>::tag) const {
@@ -219,15 +129,8 @@ namespace adm {
       detail::ParameterTraits<ScreenRef>::tag) const {
     return screenRef_ == boost::none;
   }
-  bool AudioBlockFormatObjects::isDefault(
-      detail::ParameterTraits<Importance>::tag) const {
-    return importance_ == boost::none;
-  }
 
   // ---- Setter ---- //
-  void AudioBlockFormatObjects::set(AudioBlockFormatId id) { id_ = id; }
-  void AudioBlockFormatObjects::set(Rtime rtime) { rtime_ = rtime; }
-  void AudioBlockFormatObjects::set(Duration duration) { duration_ = duration; }
   void AudioBlockFormatObjects::set(Cartesian cartesian) {
     cartesian_ = cartesian;
 
@@ -258,14 +161,9 @@ namespace adm {
     sphericalPosition_ = boost::none;
     cartesian_ = Cartesian(true);
   }
-  void AudioBlockFormatObjects::set(Width width) { width_ = width; }
-  void AudioBlockFormatObjects::set(Height height) { height_ = height; }
-  void AudioBlockFormatObjects::set(Depth depth) { depth_ = depth; }
   void AudioBlockFormatObjects::set(ScreenEdgeLock screenEdgeLock) {
     screenEdgeLock_ = screenEdgeLock;
   }
-  void AudioBlockFormatObjects::set(Gain gain) { gain_ = gain; }
-  void AudioBlockFormatObjects::set(Diffuse diffuse) { diffuse_ = diffuse; }
   void AudioBlockFormatObjects::set(ChannelLock channelLock) {
     channelLock_ = channelLock;
   }
@@ -278,17 +176,8 @@ namespace adm {
   void AudioBlockFormatObjects::set(ScreenRef screenRef) {
     screenRef_ = screenRef;
   }
-  void AudioBlockFormatObjects::set(Importance importance) {
-    importance_ = importance;
-  }
 
   // ---- Unsetter ---- //
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Rtime>::tag) {
-    rtime_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Duration>::tag) {
-    duration_ = boost::none;
-  }
   void AudioBlockFormatObjects::unset(detail::ParameterTraits<Cartesian>::tag) {
     cartesian_ = boost::none;
   }
@@ -305,24 +194,9 @@ namespace adm {
       detail::ParameterTraits<CartesianPosition>::tag) {
     cartesianPosition_ = boost::none;
   }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Width>::tag) {
-    width_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Height>::tag) {
-    height_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Depth>::tag) {
-    depth_ = boost::none;
-  }
   void AudioBlockFormatObjects::unset(
       detail::ParameterTraits<ScreenEdgeLock>::tag) {
     screenEdgeLock_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Gain>::tag) {
-    gain_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(detail::ParameterTraits<Diffuse>::tag) {
-    diffuse_ = boost::none;
   }
   void AudioBlockFormatObjects::unset(
       detail::ParameterTraits<ChannelLock>::tag) {
@@ -338,10 +212,6 @@ namespace adm {
   }
   void AudioBlockFormatObjects::unset(detail::ParameterTraits<ScreenRef>::tag) {
     screenRef_ = boost::none;
-  }
-  void AudioBlockFormatObjects::unset(
-      detail::ParameterTraits<Importance>::tag) {
-    importance_ = boost::none;
   }
 
 }  // namespace adm

--- a/src/elements/common_parameters.cpp
+++ b/src/elements/common_parameters.cpp
@@ -1,0 +1,12 @@
+#include "adm/elements/private/common_parameters.hpp"
+
+namespace adm {
+  namespace detail {
+    template class DefaultParameter<Gain>;
+
+    template class DefaultParameter<Importance>;
+
+    template class DefaultParameter<Rtime>;
+    template class OptionalParameter<Duration>;
+  }  // namespace detail
+}  // namespace adm


### PR DESCRIPTION
This automatically generates `get(Tag)`-style methods given a list of parameters.

This is currently only used for some parameters in AudioBlockFormatObjects, but can be used elsewhere as required.

Compared to the feature_automatic_base branch, the following renames have been applies:

```
s/magic_base/auto_base/
s/CombineBase/HasParameters/
s/RequiredBase/RequiredParameter/
s/OptionalBase/OptionalParameter/
s/DefaultedBase/DefaultParameter/
```

To do (probably after merging into 2076-2):
- implement a VectorParameter type
- make the documentation clearer
  - use a macro to hide the type of the base class that `AudioBlockFormatObjects` inherits from
  - add a list of parameters and behaviours to the docs for `AudioBlockFormatObjects`. This would be an improvement over the current docs, as only `set(Tag)` is listed for each supported tag, which is confusing.