### PR TITLE
fixup headphone virtualise: only export template in one place

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
-          vcpkgArguments: 'boost-variant boost-optional boost-format boost-functional boost-range boost-iterator'
+          vcpkgArguments: 'boost-variant boost-optional boost-format boost-functional boost-range boost-iterator boost-rational'
           vcpkgTriplet: '${{ matrix.triplet }}'
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           vcpkgGitCommitId: '5568f110b509a9fd90711978a7cb76bae75bb092'

--- a/include/adm/elements/audio_block_format_binaural.hpp
+++ b/include/adm/elements/audio_block_format_binaural.hpp
@@ -4,11 +4,11 @@
 #include <boost/optional.hpp>
 #include "adm/elements/time.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
+#include "adm/elements/private/common_parameters.hpp"
 #include "adm/elements_fwd.hpp"
 #include "adm/detail/named_option_helper.hpp"
 #include "adm/detail/named_type.hpp"
 #include "adm/export.h"
-#include "adm/elements/headphone_virtualise.hpp"
 #include "adm/detail/auto_base.hpp"
 
 namespace adm {
@@ -16,9 +16,6 @@ namespace adm {
   class Document;
 
   namespace detail {
-    extern template class ADM_EXPORT_TEMPLATE_METHODS
-        DefaultParameter<HeadphoneVirtualise>;
-
     using AudioBlockFormatBinauralBase =
         HasParameters<DefaultParameter<HeadphoneVirtualise>>;
   }  // namespace detail

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -5,13 +5,13 @@
 #include <boost/variant.hpp>
 #include "adm/elements/time.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
+#include "adm/elements/private/common_parameters.hpp"
 #include "adm/elements/speaker_position.hpp"
 #include "adm/elements_fwd.hpp"
 #include "adm/detail/named_option_helper.hpp"
 #include "adm/detail/named_type.hpp"
 #include "adm/detail/type_traits.hpp"
 #include "adm/export.h"
-#include "adm/elements/headphone_virtualise.hpp"
 #include "adm/detail/auto_base.hpp"
 
 namespace adm {
@@ -33,9 +33,6 @@ namespace adm {
   ADD_TRAIT(SpeakerPosition, SpeakerPostionTag);
 
   namespace detail {
-    extern template class ADM_EXPORT_TEMPLATE_METHODS
-        DefaultParameter<HeadphoneVirtualise>;
-
     using AudioBlockFormatDirectSpeakersBase =
         HasParameters<DefaultParameter<HeadphoneVirtualise>>;
   }  // namespace detail

--- a/include/adm/elements/audio_block_format_hoa.hpp
+++ b/include/adm/elements/audio_block_format_hoa.hpp
@@ -4,6 +4,7 @@
 #include <boost/optional.hpp>
 #include "adm/elements/time.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
+#include "adm/elements/private/common_parameters.hpp"
 #include "adm/elements_fwd.hpp"
 #include "adm/detail/named_option_helper.hpp"
 #include "adm/detail/named_type.hpp"
@@ -11,7 +12,6 @@
 #include "adm/elements/screen_ref.hpp"
 #include "adm/elements/nfc_ref_dist.hpp"
 #include "adm/elements/normalization.hpp"
-#include "adm/elements/headphone_virtualise.hpp"
 #include "adm/detail/auto_base.hpp"
 
 namespace adm {
@@ -34,9 +34,6 @@ namespace adm {
   using Equation = detail::NamedType<std::string, EquationTag>;
 
   namespace detail {
-    extern template class ADM_EXPORT_TEMPLATE_METHODS
-        DefaultParameter<HeadphoneVirtualise>;
-
     using AudioBlockFormatHoaBase =
         HasParameters<DefaultParameter<HeadphoneVirtualise>>;
   }  // namespace detail

--- a/include/adm/elements/audio_block_format_matrix.hpp
+++ b/include/adm/elements/audio_block_format_matrix.hpp
@@ -4,11 +4,11 @@
 #include <boost/optional.hpp>
 #include "adm/elements/time.hpp"
 #include "adm/elements/audio_block_format_id.hpp"
+#include "adm/elements/private/common_parameters.hpp"
 #include "adm/elements_fwd.hpp"
 #include "adm/detail/named_option_helper.hpp"
 #include "adm/detail/named_type.hpp"
 #include "adm/export.h"
-#include "adm/elements/headphone_virtualise.hpp"
 #include "adm/detail/auto_base.hpp"
 
 namespace adm {
@@ -16,9 +16,6 @@ namespace adm {
   class Document;
 
   namespace detail {
-    extern template class ADM_EXPORT_TEMPLATE_METHODS
-        DefaultParameter<HeadphoneVirtualise>;
-
     using AudioBlockFormatMatrixBase =
         HasParameters<DefaultParameter<HeadphoneVirtualise>>;
   }  // namespace detail

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -14,7 +14,6 @@
 #include "adm/detail/named_type.hpp"
 #include "adm/export.h"
 #include "adm/elements/screen_ref.hpp"
-#include "adm/elements/headphone_virtualise.hpp"
 
 namespace adm {
 
@@ -52,8 +51,6 @@ namespace adm {
     extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Height>;
     extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Depth>;
     extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Diffuse>;
-    extern template class ADM_EXPORT_TEMPLATE_METHODS
-        DefaultParameter<HeadphoneVirtualise>;
 
     using AudioBlockFormatObjectsBase =
         HasParameters<RequiredParameter<AudioBlockFormatId>,

--- a/include/adm/elements/private/common_parameters.hpp
+++ b/include/adm/elements/private/common_parameters.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "adm/detail/auto_base.hpp"
 #include "adm/elements/gain.hpp"
+#include "adm/elements/headphone_virtualise.hpp"
 #include "adm/elements/importance.hpp"
 #include "adm/elements/time.hpp"
 
@@ -29,5 +30,8 @@ namespace adm {
     extern template class ADM_EXPORT_TEMPLATE_METHODS DefaultParameter<Rtime>;
     extern template class ADM_EXPORT_TEMPLATE_METHODS
         OptionalParameter<Duration>;
+
+    extern template class ADM_EXPORT_TEMPLATE_METHODS
+        DefaultParameter<HeadphoneVirtualise>;
   }  // namespace detail
 }  // namespace adm

--- a/src/elements/audio_block_format_binaural.cpp
+++ b/src/elements/audio_block_format_binaural.cpp
@@ -1,10 +1,6 @@
 #include "adm/elements/audio_block_format_binaural.hpp"
 
 namespace adm {
-  namespace detail {
-    template class DefaultParameter<HeadphoneVirtualise>;
-  }
-
   namespace {
     const Rtime rtimeDefault{std::chrono::seconds(0)};
   }

--- a/src/elements/audio_block_format_direct_speakers.cpp
+++ b/src/elements/audio_block_format_direct_speakers.cpp
@@ -3,10 +3,6 @@
 #include <algorithm>
 
 namespace adm {
-  namespace detail {
-    template class DefaultParameter<HeadphoneVirtualise>;
-  }
-
   namespace {
     const Rtime rtimeDefault{std::chrono::seconds(0)};
   }

--- a/src/elements/audio_block_format_hoa.cpp
+++ b/src/elements/audio_block_format_hoa.cpp
@@ -1,10 +1,6 @@
 #include "adm/elements/audio_block_format_hoa.hpp"
 
 namespace adm {
-  namespace detail {
-    template class DefaultParameter<HeadphoneVirtualise>;
-  }
-
   // ---- Defaults ---- //
   namespace {
     const Rtime rtimeDefault{std::chrono::seconds(0)};

--- a/src/elements/audio_block_format_matrix.cpp
+++ b/src/elements/audio_block_format_matrix.cpp
@@ -1,10 +1,6 @@
 #include "adm/elements/audio_block_format_matrix.hpp"
 
 namespace adm {
-  namespace detail {
-    template class DefaultParameter<HeadphoneVirtualise>;
-  }
-
   namespace {
     const Rtime rtimeDefault{std::chrono::seconds(0)};
   }

--- a/src/elements/audio_block_format_objects.cpp
+++ b/src/elements/audio_block_format_objects.cpp
@@ -16,7 +16,6 @@ namespace adm {
     template class DefaultParameter<Height>;
     template class DefaultParameter<Depth>;
     template class DefaultParameter<Diffuse>;
-    template class DefaultParameter<HeadphoneVirtualise>;
   }  // namespace detail
 
   // ---- Getter ---- //

--- a/src/elements/common_parameters.cpp
+++ b/src/elements/common_parameters.cpp
@@ -8,5 +8,7 @@ namespace adm {
 
     template class DefaultParameter<Rtime>;
     template class OptionalParameter<Duration>;
+
+    template class DefaultParameter<HeadphoneVirtualise>;
   }  // namespace detail
 }  // namespace adm


### PR DESCRIPTION
should fix warnings in gcc; also cherry-picked the boost rational fix