### PR TITLE
export print methods

### DIFF
--- a/include/adm/elements/audio_block_format_id.hpp
+++ b/include/adm/elements/audio_block_format_id.hpp
@@ -97,7 +97,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT TypeDescriptor

--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -177,7 +177,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_channel_format_id.hpp
+++ b/include/adm/elements/audio_channel_format_id.hpp
@@ -89,7 +89,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT TypeDescriptor

--- a/include/adm/elements/audio_content.hpp
+++ b/include/adm/elements/audio_content.hpp
@@ -180,7 +180,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_content_id.hpp
+++ b/include/adm/elements/audio_content_id.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT AudioContentIdValue

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -182,7 +182,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_object_id.hpp
+++ b/include/adm/elements/audio_object_id.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT AudioObjectIdValue

--- a/include/adm/elements/audio_object_interaction.hpp
+++ b/include/adm/elements/audio_object_interaction.hpp
@@ -97,7 +97,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT OnOffInteract

--- a/include/adm/elements/audio_pack_format.hpp
+++ b/include/adm/elements/audio_pack_format.hpp
@@ -156,7 +156,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_pack_format_hoa.hpp
+++ b/include/adm/elements/audio_pack_format_hoa.hpp
@@ -70,7 +70,7 @@ namespace adm {
       /**
        * @brief Print overview to ostream
        */
-      void print(std::ostream &os) const;
+      ADM_EXPORT void print(std::ostream &os) const;
 
      private:
       friend class AudioPackFormatHoaAttorney;

--- a/include/adm/elements/audio_pack_format_id.hpp
+++ b/include/adm/elements/audio_pack_format_id.hpp
@@ -89,7 +89,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT TypeDescriptor

--- a/include/adm/elements/audio_programme.hpp
+++ b/include/adm/elements/audio_programme.hpp
@@ -172,7 +172,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_programme_id.hpp
+++ b/include/adm/elements/audio_programme_id.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT AudioProgrammeIdValue

--- a/include/adm/elements/audio_stream_format.hpp
+++ b/include/adm/elements/audio_stream_format.hpp
@@ -250,7 +250,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_stream_format_id.hpp
+++ b/include/adm/elements/audio_stream_format_id.hpp
@@ -89,7 +89,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT TypeDescriptor

--- a/include/adm/elements/audio_track_format.hpp
+++ b/include/adm/elements/audio_track_format.hpp
@@ -174,7 +174,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_track_format_id.hpp
+++ b/include/adm/elements/audio_track_format_id.hpp
@@ -97,7 +97,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT TypeDescriptor

--- a/include/adm/elements/audio_track_uid.hpp
+++ b/include/adm/elements/audio_track_uid.hpp
@@ -154,7 +154,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
     /// Get adm::Document this element belongs to
     ADM_EXPORT std::weak_ptr<Document> getParent() const;

--- a/include/adm/elements/audio_track_uid_id.hpp
+++ b/include/adm/elements/audio_track_uid_id.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT AudioTrackUidIdValue

--- a/include/adm/elements/channel_lock.hpp
+++ b/include/adm/elements/channel_lock.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT ChannelLockFlag

--- a/include/adm/elements/frequency.hpp
+++ b/include/adm/elements/frequency.hpp
@@ -99,7 +99,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT HighPass get(detail::ParameterTraits<HighPass>::tag) const;

--- a/include/adm/elements/gain_interaction_range.hpp
+++ b/include/adm/elements/gain_interaction_range.hpp
@@ -99,7 +99,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT GainInteractionMin

--- a/include/adm/elements/jump_position.hpp
+++ b/include/adm/elements/jump_position.hpp
@@ -83,7 +83,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT JumpPositionFlag

--- a/include/adm/elements/loudness_metadata.hpp
+++ b/include/adm/elements/loudness_metadata.hpp
@@ -123,7 +123,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT LoudnessMethod

--- a/include/adm/elements/object_divergence.hpp
+++ b/include/adm/elements/object_divergence.hpp
@@ -104,7 +104,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT Divergence get(detail::ParameterTraits<Divergence>::tag) const;

--- a/include/adm/elements/position.hpp
+++ b/include/adm/elements/position.hpp
@@ -87,7 +87,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT Azimuth get(detail::ParameterTraits<Azimuth>::tag) const;
@@ -187,7 +187,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT X get(detail::ParameterTraits<X>::tag) const;

--- a/include/adm/elements/position_interaction_range.hpp
+++ b/include/adm/elements/position_interaction_range.hpp
@@ -175,7 +175,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream& os) const;
+    ADM_EXPORT void print(std::ostream& os) const;
 
    private:
     ADM_EXPORT AzimuthInteractionMin

--- a/include/adm/elements/screen_edge_lock.hpp
+++ b/include/adm/elements/screen_edge_lock.hpp
@@ -102,7 +102,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT HorizontalEdge

--- a/include/adm/elements/speaker_position.hpp
+++ b/include/adm/elements/speaker_position.hpp
@@ -261,7 +261,7 @@ namespace adm {
     /**
      * @brief Print overview to ostream
      */
-    void print(std::ostream &os) const;
+    ADM_EXPORT void print(std::ostream &os) const;
 
    private:
     ADM_EXPORT Azimuth get(detail::ParameterTraits<Azimuth>::tag) const;


### PR DESCRIPTION
Add the ADM_EXPORT macro to `void print(std::ostream&) const;` declarations on all classes that have the method, to allow use from outside when compiled as a shared library.