### PR TITLE
Explicit constructors v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added support for PositionOffset sub-element in AudioObject.
 
 ### Changed
+- Most single-argument constructors have been made explicit. For most code this should not be a problem, but it may sometimes require an extra constructor call when making elements.
 - SpeakerPosition is now a boost::variant that can be either a CartesianSpeakerPosition or a SphericalSpeakerPosition
 - The previous SpeakerPosition type has been renamed to SphericalSpeakerPosition.
 - included mono (0+1+0) to the common definitions lookup tables

--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -266,7 +266,7 @@ namespace adm {
       T value_;
       ADM_BASE_EXPORT typename T::iterator find_item(Value const& item) {
         return std::find_if(
-            value_.begin(), value_.end(), [&item, this](Value const& val) {
+            value_.begin(), value_.end(), [&item](Value const& val) {
               return ParameterCompare<Value>::compare(item, val);
             });
       }

--- a/include/adm/detail/named_type_validators.hpp
+++ b/include/adm/detail/named_type_validators.hpp
@@ -7,16 +7,19 @@
 namespace adm {
 
   struct OutOfRangeError : public std::runtime_error {
-    OutOfRangeError(const char* msg) : std::runtime_error(msg) {}
-    OutOfRangeError(const std::string& msg) : std::runtime_error(msg) {}
+    explicit OutOfRangeError(const char* msg) : std::runtime_error(msg) {}
+    explicit OutOfRangeError(const std::string& msg)
+        : std::runtime_error(msg) {}
   };
   struct InvalidValueError : public std::runtime_error {
-    InvalidValueError(const char* msg) : std::runtime_error(msg) {}
-    InvalidValueError(const std::string& msg) : std::runtime_error(msg) {}
+    explicit InvalidValueError(const char* msg) : std::runtime_error(msg) {}
+    explicit InvalidValueError(const std::string& msg)
+        : std::runtime_error(msg) {}
   };
   struct InvalidStringError : public std::runtime_error {
-    InvalidStringError(const char* msg) : std::runtime_error(msg) {}
-    InvalidStringError(const std::string& msg) : std::runtime_error(msg) {}
+    explicit InvalidStringError(const char* msg) : std::runtime_error(msg) {}
+    explicit InvalidStringError(const std::string& msg)
+        : std::runtime_error(msg) {}
   };
 
   namespace detail {

--- a/include/adm/elements/audio_block_format_binaural.hpp
+++ b/include/adm/elements/audio_block_format_binaural.hpp
@@ -52,7 +52,7 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatBinaural(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatBinaural(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatBinaural(const AudioBlockFormatBinaural&) =
         default;

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -81,7 +81,7 @@ namespace adm {
     typedef AudioBlockFormatDirectSpeakersTag tag;
 
     template <typename... Parameters>
-    AudioBlockFormatDirectSpeakers(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatDirectSpeakers(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatDirectSpeakers(
         const AudioBlockFormatDirectSpeakers&) = default;

--- a/include/adm/elements/audio_block_format_id.hpp
+++ b/include/adm/elements/audio_block_format_id.hpp
@@ -36,7 +36,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioBlockFormatId(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_block_format_matrix.hpp
+++ b/include/adm/elements/audio_block_format_matrix.hpp
@@ -39,7 +39,7 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatMatrix(Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatMatrix(Parameters... optionalNamedArgs);
 
     ADM_EXPORT AudioBlockFormatMatrix(const AudioBlockFormatMatrix&) = default;
     ADM_EXPORT AudioBlockFormatMatrix(AudioBlockFormatMatrix&&) = default;

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -128,11 +128,11 @@ namespace adm {
     typedef AudioBlockFormatId id_type;
 
     template <typename... Parameters>
-    AudioBlockFormatObjects(CartesianPosition position,
-                            Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatObjects(CartesianPosition position,
+                                     Parameters... optionalNamedArgs);
     template <typename... Parameters>
-    AudioBlockFormatObjects(SphericalPosition position,
-                            Parameters... optionalNamedArgs);
+    explicit AudioBlockFormatObjects(SphericalPosition position,
+                                     Parameters... optionalNamedArgs);
     ADM_EXPORT AudioBlockFormatObjects(const AudioBlockFormatObjects&) =
         default;
     ADM_EXPORT AudioBlockFormatObjects(AudioBlockFormatObjects&&) = default;

--- a/include/adm/elements/audio_channel_format_id.hpp
+++ b/include/adm/elements/audio_channel_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioChannelFormatId(Parameters... optionalNamedArgs);
+    explicit AudioChannelFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_content.hpp
+++ b/include/adm/elements/audio_content.hpp
@@ -221,7 +221,7 @@ namespace adm {
    private:
     friend class AudioContentAttorney;
 
-    ADM_EXPORT AudioContent(AudioContentName name);
+    ADM_EXPORT explicit AudioContent(AudioContentName name);
     ADM_EXPORT AudioContent(const AudioContent&) = default;
     ADM_EXPORT AudioContent(AudioContent&&) = default;
 

--- a/include/adm/elements/audio_content_id.hpp
+++ b/include/adm/elements/audio_content_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioContentId(Parameters... optionalNamedArgs);
+    explicit AudioContentId(Parameters... optionalNamedArgs);
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     ADM_EXPORT AudioContentId(AudioContentIdValue);

--- a/include/adm/elements/audio_content_id.hpp
+++ b/include/adm/elements/audio_content_id.hpp
@@ -32,6 +32,9 @@ namespace adm {
     template <typename... Parameters>
     AudioContentId(Parameters... optionalNamedArgs);
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    ADM_EXPORT AudioContentId(AudioContentIdValue);
+
     /**
      * @brief ADM parameter getter template
      *

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -277,7 +277,7 @@ namespace adm {
    private:
     friend class AudioObjectAttorney;
 
-    ADM_EXPORT AudioObject(AudioObjectName name);
+    ADM_EXPORT explicit AudioObject(AudioObjectName name);
     ADM_EXPORT AudioObject(const AudioObject &) = default;
     ADM_EXPORT AudioObject(AudioObject &&) = default;
 

--- a/include/adm/elements/audio_object_id.hpp
+++ b/include/adm/elements/audio_object_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioObjectId(Parameters... optionalNamedArgs);
+    explicit AudioObjectId(Parameters... optionalNamedArgs);
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     ADM_EXPORT AudioObjectId(AudioObjectIdValue value);

--- a/include/adm/elements/audio_object_id.hpp
+++ b/include/adm/elements/audio_object_id.hpp
@@ -32,6 +32,9 @@ namespace adm {
     template <typename... Parameters>
     AudioObjectId(Parameters... optionalNamedArgs);
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    ADM_EXPORT AudioObjectId(AudioObjectIdValue value);
+
     /**
      * @brief ADM parameter getter template
      *

--- a/include/adm/elements/audio_object_interaction.hpp
+++ b/include/adm/elements/audio_object_interaction.hpp
@@ -42,8 +42,8 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioObjectInteraction(OnOffInteract onOffInteract,
-                           Parameters... optionalNamedArgs);
+    explicit AudioObjectInteraction(OnOffInteract onOffInteract,
+                                    Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_pack_format_hoa.hpp
+++ b/include/adm/elements/audio_pack_format_hoa.hpp
@@ -92,7 +92,7 @@ namespace adm {
 
       friend class AudioPackFormatHoaAttorney;
 
-      ADM_EXPORT AudioPackFormatHoa(AudioPackFormatName name);
+      ADM_EXPORT explicit AudioPackFormatHoa(AudioPackFormatName name);
       // ADM_EXPORT AudioPackFormatHoa(const AudioPackFormat &) = default;
       // ADM_EXPORT AudioPackFormatHoa(AudioPackFormat &&) = default;
 

--- a/include/adm/elements/audio_pack_format_id.hpp
+++ b/include/adm/elements/audio_pack_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioPackFormatId(Parameters... optionalNamedArgs);
+    explicit AudioPackFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_programme.hpp
+++ b/include/adm/elements/audio_programme.hpp
@@ -216,7 +216,7 @@ namespace adm {
    private:
     friend class AudioProgrammeAttorney;
 
-    ADM_EXPORT AudioProgramme(AudioProgrammeName name);
+    ADM_EXPORT explicit AudioProgramme(AudioProgrammeName name);
     ADM_EXPORT AudioProgramme(const AudioProgramme &) = default;
     ADM_EXPORT AudioProgramme(AudioProgramme &&) = default;
 

--- a/include/adm/elements/audio_programme_id.hpp
+++ b/include/adm/elements/audio_programme_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioProgrammeId(Parameters... optionalNamedArgs);
+    explicit AudioProgrammeId(Parameters... optionalNamedArgs);
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     ADM_EXPORT AudioProgrammeId(AudioProgrammeIdValue);

--- a/include/adm/elements/audio_programme_id.hpp
+++ b/include/adm/elements/audio_programme_id.hpp
@@ -32,6 +32,9 @@ namespace adm {
     template <typename... Parameters>
     AudioProgrammeId(Parameters... optionalNamedArgs);
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    ADM_EXPORT AudioProgrammeId(AudioProgrammeIdValue);
+
     /**
      * @brief ADM parameter getter template
      *

--- a/include/adm/elements/audio_stream_format_id.hpp
+++ b/include/adm/elements/audio_stream_format_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioStreamFormatId(Parameters... optionalNamedArgs);
+    explicit AudioStreamFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_track_format_id.hpp
+++ b/include/adm/elements/audio_track_format_id.hpp
@@ -36,7 +36,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioTrackFormatId(Parameters... optionalNamedArgs);
+    explicit AudioTrackFormatId(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/audio_track_uid_id.hpp
+++ b/include/adm/elements/audio_track_uid_id.hpp
@@ -32,6 +32,9 @@ namespace adm {
     template <typename... Parameters>
     AudioTrackUidId(Parameters... optionalNamedArgs);
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    ADM_EXPORT AudioTrackUidId(AudioTrackUidIdValue);
+
     /**
      * @brief ADM parameter getter template
      *

--- a/include/adm/elements/audio_track_uid_id.hpp
+++ b/include/adm/elements/audio_track_uid_id.hpp
@@ -30,7 +30,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    AudioTrackUidId(Parameters... optionalNamedArgs);
+    explicit AudioTrackUidId(Parameters... optionalNamedArgs);
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     ADM_EXPORT AudioTrackUidId(AudioTrackUidIdValue);

--- a/include/adm/elements/channel_lock.hpp
+++ b/include/adm/elements/channel_lock.hpp
@@ -39,7 +39,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ChannelLock(Parameters... optionalNamedArgs);
+    explicit ChannelLock(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/frequency.hpp
+++ b/include/adm/elements/frequency.hpp
@@ -51,7 +51,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    Frequency(Parameters... optionalNamedArgs);
+    explicit Frequency(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/gain_interaction_range.hpp
+++ b/include/adm/elements/gain_interaction_range.hpp
@@ -51,7 +51,7 @@ namespace adm {
      * in random order.
      */
     template <typename... Parameters>
-    GainInteractionRange(Parameters... optionalNamedArgs);
+    explicit GainInteractionRange(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/headphone_virtualise.hpp
+++ b/include/adm/elements/headphone_virtualise.hpp
@@ -39,7 +39,7 @@ namespace adm {
     typedef HeadphoneVirtualiseTag tag;
 
     template <typename... Parameters>
-    HeadphoneVirtualise(Parameters... optionalNamedArgs);
+    explicit HeadphoneVirtualise(Parameters... optionalNamedArgs);
 
     using detail::HeadphoneVirtualiseBase::get;
     using detail::HeadphoneVirtualiseBase::has;

--- a/include/adm/elements/jump_position.hpp
+++ b/include/adm/elements/jump_position.hpp
@@ -35,7 +35,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    JumpPosition(Parameters... optionalNamedArgs);
+    explicit JumpPosition(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/object_divergence.hpp
+++ b/include/adm/elements/object_divergence.hpp
@@ -54,7 +54,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ObjectDivergence(Parameters... optionalNamedArgs);
+    explicit ObjectDivergence(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/position.hpp
+++ b/include/adm/elements/position.hpp
@@ -26,8 +26,8 @@ namespace adm {
     typedef SphericalPositionTag tag;
 
     /// @brief Constructor without optional parameters
-    ADM_EXPORT SphericalPosition(Azimuth azimuth = Azimuth(0.f),
-                                 Elevation elevation = Elevation(0.f));
+    ADM_EXPORT explicit SphericalPosition(Azimuth azimuth = Azimuth(0.f),
+                                          Elevation elevation = Elevation(0.f));
     /**
      * @brief Constructor template
      *
@@ -127,7 +127,7 @@ namespace adm {
     typedef CartesianPositionTag tag;
 
     /// @brief Constructor without optional parameters
-    ADM_EXPORT CartesianPosition(X x = X(0.f), Y y = Y(1.f));
+    ADM_EXPORT explicit CartesianPosition(X x = X(0.f), Y y = Y(1.f));
 
     /**
      * @brief Constructor template

--- a/include/adm/elements/position_interaction_range.hpp
+++ b/include/adm/elements/position_interaction_range.hpp
@@ -107,7 +107,7 @@ namespace adm {
      * in random order.
      */
     template <typename... Parameters>
-    PositionInteractionRange(Parameters... optionalNamedArgs);
+    explicit PositionInteractionRange(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/screen_edge_lock.hpp
+++ b/include/adm/elements/screen_edge_lock.hpp
@@ -52,7 +52,7 @@ namespace adm {
      * in random order after the mandatory ADM parameters.
      */
     template <typename... Parameters>
-    ScreenEdgeLock(Parameters... optionalNamedArgs);
+    explicit ScreenEdgeLock(Parameters... optionalNamedArgs);
 
     /**
      * @brief ADM parameter getter template

--- a/include/adm/elements/time.hpp
+++ b/include/adm/elements/time.hpp
@@ -46,8 +46,11 @@ namespace adm {
   /// FractionalTime
   class Time {
    public:
+    // non-explicit, as this should act like a variant
     template <typename Rep, typename Period>
+    // NOLINTNEXTLINE(google-explicit-constructor)
     Time(const std::chrono::duration<Rep, Period>& time) : time(time) {}
+    // NOLINTNEXTLINE(google-explicit-constructor)
     Time(const FractionalTime& time) : time(time) {}
 
     /// convert to nanoseconds, rounding down

--- a/include/adm/errors.hpp
+++ b/include/adm/errors.hpp
@@ -48,9 +48,9 @@ namespace adm {
 
     class ADM_EXPORT XmlParsingError : public AdmException {
      public:
-      XmlParsingError(const std::string& message,
-                      boost::optional<int> line = boost::none);
-      XmlParsingError(int line);
+      explicit XmlParsingError(const std::string& message,
+                               boost::optional<int> line = boost::none);
+      explicit XmlParsingError(int line);
 
      private:
       std::string formatMessage(const std::string& message,
@@ -69,7 +69,7 @@ namespace adm {
 
     class ADM_EXPORT XmlParsingUnresolvedReference : public XmlParsingError {
      public:
-      XmlParsingUnresolvedReference(const std::string& id);
+      explicit XmlParsingUnresolvedReference(const std::string& id);
 
      private:
       std::string formatMessage(const std::string& id);

--- a/include/adm/helper/element_range.hpp
+++ b/include/adm/helper/element_range.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <memory>
+#include <vector>
 #include <boost/range/iterator_range_core.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 

--- a/include/adm/private/copy.hpp
+++ b/include/adm/private/copy.hpp
@@ -15,7 +15,7 @@ namespace adm {
   template <typename C>
   class AddTo : public boost::static_visitor<> {
    public:
-    AddTo(C& target) : target_(target) {}
+    explicit AddTo(C& target) : target_(target) {}
 
     template <typename T>
     void operator()(const T& element) const {
@@ -100,7 +100,7 @@ namespace adm {
   template <typename Element, typename Parameter>
   class ParameterEqualTo {
    public:
-    ParameterEqualTo(const Element& element)
+    explicit ParameterEqualTo(const Element& element)
         : parameter_(element.template get<Parameter>()){};
 
     inline bool operator()(const Element& other) const {

--- a/include/adm/private/xml_parser.hpp
+++ b/include/adm/private/xml_parser.hpp
@@ -68,12 +68,13 @@ namespace adm {
     NodePtr findAudioFormatExtendedNodeFullRecursive(NodePtr root);
     class XmlParser {
      public:
-      XmlParser(const std::string& filename,
-                ParserOptions options = ParserOptions::none,
-                std::shared_ptr<Document> destDocument = Document::create());
-      XmlParser(std::istream& stream,
-                ParserOptions options = ParserOptions::none,
-                std::shared_ptr<Document> destDocument = Document::create());
+      explicit XmlParser(
+          const std::string& filename,
+          ParserOptions options = ParserOptions::none,
+          std::shared_ptr<Document> destDocument = Document::create());
+      explicit XmlParser(
+          std::istream& stream, ParserOptions options = ParserOptions::none,
+          std::shared_ptr<Document> destDocument = Document::create());
 
       std::shared_ptr<Document> parse();
 

--- a/include/adm/private/xml_writer.hpp
+++ b/include/adm/private/xml_writer.hpp
@@ -7,7 +7,7 @@ namespace adm {
 
     class XmlWriter {
      public:
-      XmlWriter(WriterOptions options = WriterOptions::none);
+      explicit XmlWriter(WriterOptions options = WriterOptions::none);
 
       std::ostream& write(std::shared_ptr<const Document> document,
                           std::ostream& stream);

--- a/include/adm/route.hpp
+++ b/include/adm/route.hpp
@@ -76,7 +76,7 @@ namespace adm {
 
    private:
     struct AddVisitor : public boost::static_visitor<> {
-      AddVisitor(Route& admRoute) : admRoute_(admRoute) {}
+      explicit AddVisitor(Route& admRoute) : admRoute_(admRoute) {}
 
       template <typename Element>
       void operator()(std::shared_ptr<Element> element) const {

--- a/src/elements/audio_content_id.cpp
+++ b/src/elements/audio_content_id.cpp
@@ -6,6 +6,9 @@
 
 namespace adm {
 
+  // ---- Constructor ---- //
+  AudioContentId::AudioContentId(AudioContentIdValue value) : value_(value) {}
+
   // ---- Defaults ---- //
   const AudioContentIdValue AudioContentId::valueDefault_ =
       AudioContentIdValue(0);

--- a/src/elements/audio_object_id.cpp
+++ b/src/elements/audio_object_id.cpp
@@ -6,6 +6,9 @@
 
 namespace adm {
 
+  // ---- Constructor ---- //
+  AudioObjectId::AudioObjectId(AudioObjectIdValue value) : value_(value) {}
+
   // ---- Defaults ---- //
   const AudioObjectIdValue AudioObjectId::valueDefault_ = AudioObjectIdValue(0);
 

--- a/src/elements/audio_programme_id.cpp
+++ b/src/elements/audio_programme_id.cpp
@@ -6,6 +6,10 @@
 
 namespace adm {
 
+  // ---- Constructor ---- //
+  AudioProgrammeId::AudioProgrammeId(AudioProgrammeIdValue value)
+      : value_(value) {}
+
   // ---- Defaults ---- //
   const AudioProgrammeIdValue AudioProgrammeId::valueDefault_ =
       AudioProgrammeIdValue(0);

--- a/src/elements/audio_track_uid_id.cpp
+++ b/src/elements/audio_track_uid_id.cpp
@@ -6,6 +6,10 @@
 
 namespace adm {
 
+  // ---- Constructor ---- //
+  AudioTrackUidId::AudioTrackUidId(AudioTrackUidIdValue value)
+      : value_(value) {}
+
   // ---- Defaults ---- //
   const AudioTrackUidIdValue AudioTrackUidId::valueDefault_ =
       AudioTrackUidIdValue(0);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3,7 +3,7 @@
 namespace adm {
 
   struct AddElementVisitor : public boost::static_visitor<> {
-    AddElementVisitor(Path* path) : path_(path) {}
+    explicit AddElementVisitor(Path* path) : path_(path) {}
 
     template <typename T>
     void operator()(T v) const {
@@ -15,7 +15,7 @@ namespace adm {
   };
 
   struct AddIdVisitor : public boost::static_visitor<> {
-    AddIdVisitor(Path* path) : path_(path) {}
+    explicit AddIdVisitor(Path* path) : path_(path) {}
 
     template <typename T>
     void operator()(T v) const {

--- a/tests/audio_object_tests.cpp
+++ b/tests/audio_object_tests.cpp
@@ -48,7 +48,7 @@ TEST_CASE("audio_object parameter checks") {
   }
   SECTION("AudioObjectInteraction") {
     check_optional_param<AudioObjectInteraction>(
-        audioObject, canBeSetTo(OnOffInteract(true)));
+        audioObject, canBeSetTo(AudioObjectInteraction(OnOffInteract(true))));
   }
   SECTION("Labels") {
     check_vector_param<Labels>(audioObject,

--- a/tests/auto_base_tests.cpp
+++ b/tests/auto_base_tests.cpp
@@ -47,7 +47,7 @@ namespace adm {
   // the future, and this shows how it will typically be used.
   struct TestElement : private detail::Base {
     template <typename... Parameters>
-    TestElement(Parameters... namedArgs) {
+    explicit TestElement(Parameters... namedArgs) {
       detail::setNamedOptionHelper(this,
                                    std::forward<Parameters>(namedArgs)...);
     }

--- a/tests/helper/file_comparator.hpp
+++ b/tests/helper/file_comparator.hpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <string>
 #include <streambuf>
+#include <catch2/catch.hpp>
 
 class FileComparator : public Catch::MatcherBase<std::string> {
  public:


### PR DESCRIPTION
replaces #54

This is a bit more complete, covering errors and utilities too.

Basically apply this: https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html -- so any single-argument constructors (including templates) are marked as explicit.

Exceptions are made for:
- `Time`: this should behave like a variant, and being able to do `Duration(std::chrono::seconds{1})` is handy.
- ID types that only hold a single value. The value types are only used in one place, so it's helpful (and not harmful) to be able to use implicit conversions for them.