### PR TITLE
add compatibility aliases to Gain class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Added support for Cartesian speaker positions.
 - Added support for AudioChannelFormatIDRef in AudioTrackUID as per BS.2076-2
-- Added support for dB gains. `Gain{1.0}` should be replaced with `Gain::fromLinear(1.0)`, and `b.get<Gain>().get()` should be replaced with `b.get<Gain>().asLinear()`.
+- Added support for dB gains. For clarity, `Gain{1.0}` should be replaced with `Gain::fromLinear(1.0)`, and `b.get<Gain>().get()` should be replaced with `b.get<Gain>().asLinear()`, though the old API should continue to work.
 - Added BS.2076-2 gain attribute to audioObjects and all audioBlockFormat types.
 - Added BS.2076-2 headLocked attribute to audioObjects and audioBlockFormats.
 - Added support for headphoneVirtualise in audioBlockFormat as per BS.2076-2.

--- a/include/adm/elements/gain.hpp
+++ b/include/adm/elements/gain.hpp
@@ -12,6 +12,9 @@ namespace adm {
    public:
     typedef GainTag tag;
 
+    /// alias for Gain::fromLinear for compatibility with existing code
+    explicit Gain(double linearGain) : _gain(linearGain), _isDb(false) {}
+
     /// Make a linear Gain.
     static Gain fromLinear(double linearGain) {
       return Gain{linearGain, false};
@@ -40,6 +43,11 @@ namespace adm {
     bool isLinear() const { return !_isDb; }
     /// Is this gain stored in dB?
     bool isDb() const { return _isDb; }
+
+    /// alias for asLinear for compatibility with existing code
+    double get() const { return asLinear(); }
+    /// alias for asLinear for compatibility with existing code
+    double operator*() const { return asLinear(); }
 
    private:
     Gain(double gain, bool isDb) : _gain(gain), _isDb(isDb) {}

--- a/tests/gain_tests.cpp
+++ b/tests/gain_tests.cpp
@@ -29,3 +29,10 @@ TEST_CASE("Gain Db -inf") {
   Gain g = Gain::fromDb(-std::numeric_limits<double>::infinity());
   CHECK(g.asLinear() == 0.0);
 }
+
+TEST_CASE("Gain NamedType compatibility") {
+  Gain g(1.5);
+  CHECK(g.isLinear());
+  CHECK(g.get() == 1.5);
+  CHECK(*g == 1.5);
+}


### PR DESCRIPTION
comparisons are not supported, but cases using these are probably easy to fix -- this is mostly to help users which rely on generic templated access to parameters