### PR TITLE
fixes use of std::forward without forwarding references (and more moves)

### DIFF
--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -169,7 +169,7 @@ namespace adm {
       static constexpr bool has_get_set_has = true;
 
       ADM_BASE_EXPORT T get(Tag) const { return value_; }
-      ADM_BASE_EXPORT void set(T value) { value_ = value; }
+      ADM_BASE_EXPORT void set(T value) { value_ = std::move(value); }
       ADM_BASE_EXPORT bool has(Tag) const { return true; }
 
      private:
@@ -188,7 +188,7 @@ namespace adm {
       static constexpr bool has_isDefault_unset = true;
 
       ADM_BASE_EXPORT T get(Tag) const { return value_.get(); }
-      ADM_BASE_EXPORT void set(T value) { value_ = value; }
+      ADM_BASE_EXPORT void set(T value) { value_ = std::move(value); }
       ADM_BASE_EXPORT bool has(Tag) const { return value_ != boost::none; }
       ADM_BASE_EXPORT bool isDefault(Tag) const { return false; }
       ADM_BASE_EXPORT void unset(Tag) { value_ = boost::none; }
@@ -211,7 +211,7 @@ namespace adm {
       ADM_BASE_EXPORT T get(Tag) const {
         return boost::get_optional_value_or(value_, getDefault<T>());
       }
-      ADM_BASE_EXPORT void set(T value) { value_ = value; }
+      ADM_BASE_EXPORT void set(T value) { value_ = std::move(value); }
       ADM_BASE_EXPORT bool has(Tag) const { return true; }
       ADM_BASE_EXPORT bool isDefault(Tag) const {
         return value_ == boost::none;
@@ -242,7 +242,7 @@ namespace adm {
       static constexpr bool has_add_remove = true;
 
       ADM_BASE_EXPORT T get(Tag) const { return value_; }
-      ADM_BASE_EXPORT void set(T value) { value_ = value; }
+      ADM_BASE_EXPORT void set(T value) { value_ = std::move(value); }
       ADM_BASE_EXPORT bool has(Tag) const { return value_.size() > 0; }
       ADM_BASE_EXPORT bool isDefault(Tag) const { return false; }
       ADM_BASE_EXPORT void unset(Tag) { value_.clear(); }
@@ -250,7 +250,7 @@ namespace adm {
       ADM_BASE_EXPORT bool add(Value item) {
         auto it = find_item(item);
         if (it == value_.end()) {
-          value_.push_back(item);
+          value_.push_back(std::move(item));
           return true;
         } else {
           return false;
@@ -290,7 +290,9 @@ namespace adm {
       }
 
       using VariantParam::set;
-      ADM_BASE_EXPORT void set(T value) { return VariantParam::set(value); }
+      ADM_BASE_EXPORT void set(T value) {
+        return VariantParam::set(std::move(value));
+      }
 
       using VariantParam::has;
       ADM_BASE_EXPORT bool has(Tag) const {

--- a/include/adm/detail/auto_base.hpp
+++ b/include/adm/detail/auto_base.hpp
@@ -257,7 +257,7 @@ namespace adm {
         }
       }
 
-      ADM_BASE_EXPORT void remove(Value item) {
+      ADM_BASE_EXPORT void remove(Value const& item) {
         auto it = find_item(item);
         if (it != value_.end()) value_.erase(it);
       }

--- a/include/adm/detail/named_option_helper.hpp
+++ b/include/adm/detail/named_option_helper.hpp
@@ -11,15 +11,10 @@ namespace adm {
     inline void setNamedOptionHelper(Element /*element*/) {}
 
     template <typename Element, typename T, typename... Parameters>
-    void setNamedOptionHelper(Element element, const T& v, Parameters... args) {
-      element->set(v);
+    void setNamedOptionHelper(Element element, T v, Parameters... args) {
+      element->set(std::move(v));
 
-      setNamedOptionHelper(element, std::forward<Parameters>(args)...);
-    }
-
-    template <typename Element, typename T>
-    void setNamedOptionHelper(Element element, const T& v) {
-      element->set(v);
+      setNamedOptionHelper(element, std::move(args)...);
     }
 
   }  // namespace detail

--- a/include/adm/detail/named_option_helper.hpp
+++ b/include/adm/detail/named_option_helper.hpp
@@ -8,13 +8,13 @@ namespace adm {
   namespace detail {
 
     template <typename Element>
-    inline void setNamedOptionHelper(Element /*element*/) {}
+    inline void setNamedOptionHelper(Element&& /*element*/) {}
 
     template <typename Element, typename T, typename... Parameters>
-    void setNamedOptionHelper(Element element, T v, Parameters... args) {
+    void setNamedOptionHelper(Element&& element, T v, Parameters... args) {
       element->set(std::move(v));
 
-      setNamedOptionHelper(element, std::move(args)...);
+      setNamedOptionHelper(std::forward<Element>(element), std::move(args)...);
     }
 
   }  // namespace detail

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -26,7 +26,7 @@ namespace adm {
       explicit NamedType(T const& value) : value_(value) {
         Validator::validate(get());
       }
-      explicit NamedType(T&& value) : value_(value) {
+      explicit NamedType(T&& value) : value_(std::move(value)) {
         Validator::validate(get());
       }
       T& get() { return value_; }

--- a/include/adm/elements/audio_block_format_binaural.hpp
+++ b/include/adm/elements/audio_block_format_binaural.hpp
@@ -144,8 +144,7 @@ namespace adm {
   template <typename... Parameters>
   AudioBlockFormatBinaural::AudioBlockFormatBinaural(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -149,7 +149,7 @@ namespace adm {
     /// @brief Add a SpeakerLabel
     ADM_EXPORT bool add(SpeakerLabel label);
     /// @brief remove a SpeakerLabel
-    ADM_EXPORT void remove(SpeakerLabel label);
+    ADM_EXPORT void remove(const SpeakerLabel& label);
 
    private:
     using detail::AudioBlockFormatDirectSpeakersBase::get;

--- a/include/adm/elements/audio_block_format_direct_speakers.hpp
+++ b/include/adm/elements/audio_block_format_direct_speakers.hpp
@@ -198,8 +198,7 @@ namespace adm {
   template <typename... Parameters>
   AudioBlockFormatDirectSpeakers::AudioBlockFormatDirectSpeakers(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/audio_block_format_hoa.hpp
+++ b/include/adm/elements/audio_block_format_hoa.hpp
@@ -165,7 +165,7 @@ namespace adm {
     set(order);
     set(degree);
     detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+        this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/audio_block_format_id.hpp
+++ b/include/adm/elements/audio_block_format_id.hpp
@@ -150,8 +150,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioBlockFormatId::AudioBlockFormatId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_block_format_matrix.hpp
+++ b/include/adm/elements/audio_block_format_matrix.hpp
@@ -128,8 +128,7 @@ namespace adm {
   template <typename... Parameters>
   AudioBlockFormatMatrix::AudioBlockFormatMatrix(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/audio_block_format_objects.hpp
+++ b/include/adm/elements/audio_block_format_objects.hpp
@@ -281,16 +281,14 @@ namespace adm {
   AudioBlockFormatObjects::AudioBlockFormatObjects(
       CartesianPosition position, Parameters... optionalNamedArgs) {
     set(position);
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename... Parameters>
   AudioBlockFormatObjects::AudioBlockFormatObjects(
       SphericalPosition position, Parameters... optionalNamedArgs) {
     set(position);
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -306,7 +306,7 @@ namespace adm {
       AudioChannelFormatName name, TypeDescriptor channelType,
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioChannelFormat> channel(
-        new AudioChannelFormat(name, channelType));
+        new AudioChannelFormat(std::move(name), channelType));
     detail::setNamedOptionHelper(
         channel, std::move(optionalNamedArgs)...);
     return channel;

--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -308,7 +308,7 @@ namespace adm {
     std::shared_ptr<AudioChannelFormat> channel(
         new AudioChannelFormat(name, channelType));
     detail::setNamedOptionHelper(
-        channel, std::forward<Parameters>(optionalNamedArgs)...);
+        channel, std::move(optionalNamedArgs)...);
     return channel;
   }
 

--- a/include/adm/elements/audio_channel_format_id.hpp
+++ b/include/adm/elements/audio_channel_format_id.hpp
@@ -134,8 +134,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioChannelFormatId::AudioChannelFormatId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_content.hpp
+++ b/include/adm/elements/audio_content.hpp
@@ -299,7 +299,7 @@ namespace adm {
   template <typename... Parameters>
   std::shared_ptr<AudioContent> AudioContent::create(
       AudioContentName name, Parameters... optionalNamedArgs) {
-    std::shared_ptr<AudioContent> content(new AudioContent(name));
+    std::shared_ptr<AudioContent> content(new AudioContent(std::move(name)));
     detail::setNamedOptionHelper(content, std::move(optionalNamedArgs)...);
 
     return content;

--- a/include/adm/elements/audio_content.hpp
+++ b/include/adm/elements/audio_content.hpp
@@ -300,8 +300,7 @@ namespace adm {
   std::shared_ptr<AudioContent> AudioContent::create(
       AudioContentName name, Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioContent> content(new AudioContent(name));
-    detail::setNamedOptionHelper(
-        content, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(content, std::move(optionalNamedArgs)...);
 
     return content;
   }

--- a/include/adm/elements/audio_content_id.hpp
+++ b/include/adm/elements/audio_content_id.hpp
@@ -124,8 +124,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioContentId::AudioContentId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -377,7 +377,7 @@ namespace adm {
   template <typename... Parameters>
   std::shared_ptr<AudioObject> AudioObject::create(
       AudioObjectName name, Parameters... optionalNamedArgs) {
-    std::shared_ptr<AudioObject> object(new AudioObject(name));
+    std::shared_ptr<AudioObject> object(new AudioObject(std::move(name)));
     detail::setNamedOptionHelper(object, std::move(optionalNamedArgs)...);
 
     return object;

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -378,8 +378,7 @@ namespace adm {
   std::shared_ptr<AudioObject> AudioObject::create(
       AudioObjectName name, Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioObject> object(new AudioObject(name));
-    detail::setNamedOptionHelper(
-        object, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(object, std::move(optionalNamedArgs)...);
 
     return object;
   }

--- a/include/adm/elements/audio_object_id.hpp
+++ b/include/adm/elements/audio_object_id.hpp
@@ -123,8 +123,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioObjectId::AudioObjectId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_object_interaction.hpp
+++ b/include/adm/elements/audio_object_interaction.hpp
@@ -143,8 +143,7 @@ namespace adm {
   AudioObjectInteraction::AudioObjectInteraction(
       OnOffInteract onOffInteract, Parameters... optionalNamedArgs)
       : onOffInteract_(onOffInteract) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_pack_format.hpp
+++ b/include/adm/elements/audio_pack_format.hpp
@@ -259,7 +259,7 @@ namespace adm {
       std::shared_ptr<AudioPackFormat> pack(
           new AudioPackFormat(name, channelType));
       detail::setNamedOptionHelper(
-          pack, std::forward<Parameters>(optionalNamedArgs)...);
+          pack, std::move(optionalNamedArgs)...);
       return pack;
     }
   }

--- a/include/adm/elements/audio_pack_format.hpp
+++ b/include/adm/elements/audio_pack_format.hpp
@@ -257,7 +257,7 @@ namespace adm {
     } else {
 
       std::shared_ptr<AudioPackFormat> pack(
-          new AudioPackFormat(name, channelType));
+          new AudioPackFormat(std::move(name), channelType));
       detail::setNamedOptionHelper(
           pack, std::move(optionalNamedArgs)...);
       return pack;

--- a/include/adm/elements/audio_pack_format_hoa.hpp
+++ b/include/adm/elements/audio_pack_format_hoa.hpp
@@ -112,7 +112,7 @@ namespace adm {
         AudioPackFormatName name, Parameters... optionalNamedArgs) {
       std::shared_ptr<AudioPackFormatHoa> pack(new AudioPackFormatHoa(name));
       detail::setNamedOptionHelper(
-          pack, std::forward<Parameters>(optionalNamedArgs)...);
+          pack, std::move(optionalNamedArgs)...);
       return pack;
     }
 

--- a/include/adm/elements/audio_pack_format_id.hpp
+++ b/include/adm/elements/audio_pack_format_id.hpp
@@ -131,8 +131,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioPackFormatId::AudioPackFormatId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_programme.hpp
+++ b/include/adm/elements/audio_programme.hpp
@@ -291,7 +291,8 @@ namespace adm {
   template <typename... Parameters>
   std::shared_ptr<AudioProgramme> AudioProgramme::create(
       AudioProgrammeName name, Parameters... optionalNamedArgs) {
-    std::shared_ptr<AudioProgramme> programme(new AudioProgramme(name));
+    std::shared_ptr<AudioProgramme> programme(
+        new AudioProgramme(std::move(name)));
     detail::setNamedOptionHelper(programme, std::move(optionalNamedArgs)...);
 
     return programme;

--- a/include/adm/elements/audio_programme.hpp
+++ b/include/adm/elements/audio_programme.hpp
@@ -292,8 +292,7 @@ namespace adm {
   std::shared_ptr<AudioProgramme> AudioProgramme::create(
       AudioProgrammeName name, Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioProgramme> programme(new AudioProgramme(name));
-    detail::setNamedOptionHelper(
-        programme, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(programme, std::move(optionalNamedArgs)...);
 
     return programme;
   }

--- a/include/adm/elements/audio_programme_id.hpp
+++ b/include/adm/elements/audio_programme_id.hpp
@@ -124,8 +124,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioProgrammeId::AudioProgrammeId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_stream_format.hpp
+++ b/include/adm/elements/audio_stream_format.hpp
@@ -319,7 +319,7 @@ namespace adm {
       AudioStreamFormatName name, FormatDescriptor format,
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioStreamFormat> streamFormat(
-        new AudioStreamFormat(name, format));
+        new AudioStreamFormat(std::move(name), format));
     detail::setNamedOptionHelper(streamFormat, std::move(optionalNamedArgs)...);
 
     return streamFormat;

--- a/include/adm/elements/audio_stream_format.hpp
+++ b/include/adm/elements/audio_stream_format.hpp
@@ -320,8 +320,7 @@ namespace adm {
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioStreamFormat> streamFormat(
         new AudioStreamFormat(name, format));
-    detail::setNamedOptionHelper(
-        streamFormat, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(streamFormat, std::move(optionalNamedArgs)...);
 
     return streamFormat;
   }

--- a/include/adm/elements/audio_stream_format_id.hpp
+++ b/include/adm/elements/audio_stream_format_id.hpp
@@ -133,8 +133,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioStreamFormatId::AudioStreamFormatId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_track_format.hpp
+++ b/include/adm/elements/audio_track_format.hpp
@@ -234,8 +234,7 @@ namespace adm {
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioTrackFormat> trackFormat(
         new AudioTrackFormat(name, format));
-    detail::setNamedOptionHelper(
-        trackFormat, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(trackFormat, std::move(optionalNamedArgs)...);
 
     return trackFormat;
   }

--- a/include/adm/elements/audio_track_format.hpp
+++ b/include/adm/elements/audio_track_format.hpp
@@ -233,7 +233,7 @@ namespace adm {
       AudioTrackFormatName name, FormatDescriptor format,
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioTrackFormat> trackFormat(
-        new AudioTrackFormat(name, format));
+        new AudioTrackFormat(std::move(name), format));
     detail::setNamedOptionHelper(trackFormat, std::move(optionalNamedArgs)...);
 
     return trackFormat;

--- a/include/adm/elements/audio_track_format_id.hpp
+++ b/include/adm/elements/audio_track_format_id.hpp
@@ -150,8 +150,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioTrackFormatId::AudioTrackFormatId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/audio_track_uid.hpp
+++ b/include/adm/elements/audio_track_uid.hpp
@@ -223,8 +223,7 @@ namespace adm {
   std::shared_ptr<AudioTrackUid> AudioTrackUid::create(
       Parameters... optionalNamedArgs) {
     std::shared_ptr<AudioTrackUid> trackUid(new AudioTrackUid());
-    detail::setNamedOptionHelper(
-        trackUid, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(trackUid, std::move(optionalNamedArgs)...);
 
     return trackUid;
   }

--- a/include/adm/elements/audio_track_uid_id.hpp
+++ b/include/adm/elements/audio_track_uid_id.hpp
@@ -124,8 +124,7 @@ namespace adm {
   // ---- Implementation ---- //
   template <typename... Parameters>
   AudioTrackUidId::AudioTrackUidId(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/channel_lock.hpp
+++ b/include/adm/elements/channel_lock.hpp
@@ -129,8 +129,7 @@ namespace adm {
 
   template <typename... Parameters>
   ChannelLock::ChannelLock(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/frequency.hpp
+++ b/include/adm/elements/frequency.hpp
@@ -134,8 +134,7 @@ namespace adm {
 
   template <typename... Parameters>
   Frequency::Frequency(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/gain_interaction_range.hpp
+++ b/include/adm/elements/gain_interaction_range.hpp
@@ -130,8 +130,7 @@ namespace adm {
 
   template <typename... Parameters>
   GainInteractionRange::GainInteractionRange(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/headphone_virtualise.hpp
+++ b/include/adm/elements/headphone_virtualise.hpp
@@ -110,7 +110,6 @@ namespace adm {
 
   template <typename... Parameters>
   HeadphoneVirtualise::HeadphoneVirtualise(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 }  // namespace adm

--- a/include/adm/elements/jump_position.hpp
+++ b/include/adm/elements/jump_position.hpp
@@ -137,8 +137,7 @@ namespace adm {
 
   template <typename... Parameters>
   JumpPosition::JumpPosition(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/label.hpp
+++ b/include/adm/elements/label.hpp
@@ -40,8 +40,7 @@ namespace adm {
 
     template <typename... Parameters>
     explicit Label(Parameters... namedArgs) {
-      detail::setNamedOptionHelper(this,
-                                   std::forward<Parameters>(namedArgs)...);
+      detail::setNamedOptionHelper(this, std::move(namedArgs)...);
     }
 
     ADM_EXPORT explicit Label(std::string str)

--- a/include/adm/elements/loudness_metadata.hpp
+++ b/include/adm/elements/loudness_metadata.hpp
@@ -191,8 +191,7 @@ namespace adm {
 
   template <typename... Parameters>
   LoudnessMetadata::LoudnessMetadata(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   };
 
   template <typename Parameter>

--- a/include/adm/elements/object_divergence.hpp
+++ b/include/adm/elements/object_divergence.hpp
@@ -143,8 +143,7 @@ namespace adm {
 
   template <typename... Parameters>
   ObjectDivergence::ObjectDivergence(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/position.hpp
+++ b/include/adm/elements/position.hpp
@@ -236,8 +236,7 @@ namespace adm {
   SphericalPosition::SphericalPosition(Azimuth azimuth, Elevation elevation,
                                        Parameters... optionalNamedArgs)
       : azimuth_(azimuth), elevation_(elevation) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>
@@ -268,8 +267,7 @@ namespace adm {
   CartesianPosition::CartesianPosition(X x, Y y,
                                        Parameters... optionalNamedArgs)
       : x_(x), y_(y) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/position_interaction_range.hpp
+++ b/include/adm/elements/position_interaction_range.hpp
@@ -286,8 +286,7 @@ namespace adm {
   template <typename... Parameters>
   PositionInteractionRange::PositionInteractionRange(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/position_offset.hpp
+++ b/include/adm/elements/position_offset.hpp
@@ -154,15 +154,13 @@ namespace adm {
   template <typename... Parameters>
   SphericalPositionOffset::SphericalPositionOffset(
       Parameters&&... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename... Parameters>
   CartesianPositionOffset::CartesianPositionOffset(
       Parameters&&... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
 }  // namespace adm

--- a/include/adm/elements/screen_edge_lock.hpp
+++ b/include/adm/elements/screen_edge_lock.hpp
@@ -129,8 +129,7 @@ namespace adm {
 
   template <typename... Parameters>
   ScreenEdgeLock::ScreenEdgeLock(Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/elements/speaker_position.hpp
+++ b/include/adm/elements/speaker_position.hpp
@@ -154,8 +154,7 @@ namespace adm {
   template <typename... Parameters>
   CartesianSpeakerPosition::CartesianSpeakerPosition(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>
@@ -322,8 +321,7 @@ namespace adm {
   template <typename... Parameters>
   SphericalSpeakerPosition::SphericalSpeakerPosition(
       Parameters... optionalNamedArgs) {
-    detail::setNamedOptionHelper(
-        this, std::forward<Parameters>(optionalNamedArgs)...);
+    detail::setNamedOptionHelper(this, std::move(optionalNamedArgs)...);
   }
 
   template <typename Parameter>

--- a/include/adm/private/xml_parser_helper.hpp
+++ b/include/adm/private/xml_parser_helper.hpp
@@ -149,7 +149,7 @@ namespace adm {
                       Callable parser) {
       auto value = parseOptionalAttribute<NT>(node, attributeName, parser);
       if (value != boost::none) {
-        return value.get();
+        return std::move(value.get());
       } else {
         std::stringstream errorString;
         int errorLine = getDocumentLine(node);
@@ -170,7 +170,7 @@ namespace adm {
                               Target& target, Callable parser) {
       auto value = parseOptionalAttribute<NT>(node, attributeName, parser);
       if (value != boost::none) {
-        detail::invokeSet(target, value.get());
+        detail::invokeSet(target, std::move(value.get()));
       }
     }
 
@@ -198,7 +198,7 @@ namespace adm {
     NT parseElement(NodePtr node, const char* elementName, Callable parser) {
       auto value = parseOptionalElement<NT>(node, elementName, parser);
       if (value != boost::none) {
-        return value.get();
+        return std::move(value.get());
       } else {
         std::stringstream errorString;
         int errorLine = getDocumentLine(node);
@@ -213,7 +213,7 @@ namespace adm {
                             Target& target, Callable parser) {
       auto value = parseOptionalElement<NT>(node, elementName, parser);
       if (value != boost::none) {
-        detail::invokeAdd(target, value.get());
+        detail::invokeAdd(target, std::move(value.get()));
       }
     }
 
@@ -231,7 +231,7 @@ namespace adm {
                             Target& target, Callable parser) {
       auto value = parseOptionalElement<NT>(node, elementName, parser);
       if (value != boost::none) {
-        detail::invokeSet(target, value.get());
+        detail::invokeSet(target, std::move(value.get()));
       }
     }
 
@@ -261,7 +261,7 @@ namespace adm {
                                  Target& target, Callable parser) {
       auto value = parseOptionalMultiElement<NT>(node, elementName, parser);
       if (value != boost::none) {
-        detail::invokeSet(target, value.get());
+        detail::invokeSet(target, std::move(value.get()));
       }
     }
 
@@ -270,7 +270,7 @@ namespace adm {
                          Callable parser) {
       auto value = parseOptionalMultiElement<NT>(node, elementName, parser);
       if (value != boost::none) {
-        detail::invokeSet(target, value.get());
+        detail::invokeSet(target, std::move(value.get()));
       } else {
         std::stringstream errorString;
         int errorLine = getDocumentLine(node);

--- a/include/adm/private/xml_parser_helper.hpp
+++ b/include/adm/private/xml_parser_helper.hpp
@@ -95,7 +95,7 @@ namespace adm {
                                     TypeTag<unsigned int>) {
         return std::stoul(v);
       }
-      inline std::string parseImpl(const std::string& v, TypeTag<std::string>) {
+      inline std::string parseImpl(std::string v, TypeTag<std::string>) {
         return v;
       }
       inline float parseImpl(const std::string& v, TypeTag<float>) {
@@ -109,10 +109,10 @@ namespace adm {
       }
 
       template <typename NT>
-      NT parseDefault(const std::string& v) {
+      NT parseDefault(std::string v) {
         typedef typename NT::value_type value_type;
         typedef TypeTag<value_type> DispatchTypeTag;
-        return NT(parseImpl(v, DispatchTypeTag()));
+        return NT(parseImpl(std::move(v), DispatchTypeTag()));
       }
     }  // namespace detail
 

--- a/src/elements/audio_block_format_direct_speakers.cpp
+++ b/src/elements/audio_block_format_direct_speakers.cpp
@@ -110,7 +110,8 @@ namespace adm {
   }
 
   // ---- Remove ---- //
-  void AudioBlockFormatDirectSpeakers::remove(SpeakerLabel speakerLabel) {
+  void AudioBlockFormatDirectSpeakers::remove(
+      const SpeakerLabel &speakerLabel) {
     auto it =
         std::find(speakerLabels_.begin(), speakerLabels_.end(), speakerLabel);
     if (it != speakerLabels_.end()) {

--- a/src/elements/audio_block_format_direct_speakers.cpp
+++ b/src/elements/audio_block_format_direct_speakers.cpp
@@ -102,7 +102,7 @@ namespace adm {
     auto it =
         std::find(speakerLabels_.begin(), speakerLabels_.end(), speakerLabel);
     if (it == speakerLabels_.end()) {
-      speakerLabels_.push_back(speakerLabel);
+      speakerLabels_.push_back(std::move(speakerLabel));
       return true;
     } else {
       return false;

--- a/src/elements/audio_channel_format.cpp
+++ b/src/elements/audio_channel_format.cpp
@@ -61,7 +61,9 @@ namespace adm {
       throw std::runtime_error(errorString.str());
     }
   }
-  void AudioChannelFormat::set(AudioChannelFormatName name) { name_ = name; }
+  void AudioChannelFormat::set(AudioChannelFormatName name) {
+    name_ = std::move(name);
+  }
   void AudioChannelFormat::set(Frequency frequency) { frequency_ = frequency; }
 
   // ---- Has ---- //
@@ -222,6 +224,6 @@ namespace adm {
 
   AudioChannelFormat::AudioChannelFormat(AudioChannelFormatName name,
                                          TypeDescriptor channelType)
-      : name_(name), typeDescriptor_(channelType) {}
+      : name_(std::move(name)), typeDescriptor_(channelType) {}
 
 }  // namespace adm

--- a/src/elements/audio_content.cpp
+++ b/src/elements/audio_content.cpp
@@ -91,9 +91,9 @@ namespace adm {
     }
     id_ = id;
   }
-  void AudioContent::set(AudioContentName name) { name_ = name; }
+  void AudioContent::set(AudioContentName name) { name_ = std::move(name); }
   void AudioContent::set(AudioContentLanguage language) {
-    language_ = language;
+    language_ = std::move(language);
   }
   void AudioContent::set(DialogueId id) {
     if (dialogueId_ && dialogueId_.get() == id) {
@@ -242,6 +242,6 @@ namespace adm {
     return audioContentCopy;
   }
 
-  AudioContent::AudioContent(AudioContentName name) : name_(name) {}
+  AudioContent::AudioContent(AudioContentName name) : name_(std::move(name)) {}
 
 }  // namespace adm

--- a/src/elements/audio_object.cpp
+++ b/src/elements/audio_object.cpp
@@ -106,7 +106,7 @@ namespace adm {
     }
     id_ = id;
   }
-  void AudioObject::set(AudioObjectName name) { name_ = name; }
+  void AudioObject::set(AudioObjectName name) { name_ = std::move(name); }
   void AudioObject::set(Start start) { start_ = start; }
   void AudioObject::set(Duration duration) { duration_ = duration; }
   void AudioObject::set(DialogueId id) { dialogueId_ = id; }
@@ -349,6 +349,6 @@ namespace adm {
     return audioObjectCopy;
   }
 
-  AudioObject::AudioObject(AudioObjectName name) : name_(name) {}
+  AudioObject::AudioObject(AudioObjectName name) : name_(std::move(name)) {}
 
 }  // namespace adm

--- a/src/elements/audio_pack_format.cpp
+++ b/src/elements/audio_pack_format.cpp
@@ -53,7 +53,7 @@ namespace adm {
       throw std::runtime_error(errorString.str());
     }
   }
-  void AudioPackFormat::set(AudioPackFormatName name) { name_ = name; }
+  void AudioPackFormat::set(AudioPackFormatName name) { name_ = std::move(name); }
   void AudioPackFormat::set(Importance importance) { importance_ = importance; }
   void AudioPackFormat::set(AbsoluteDistance absoluteDistance) {
     absoluteDistance_ = absoluteDistance;
@@ -206,7 +206,7 @@ namespace adm {
 
   AudioPackFormat::AudioPackFormat(AudioPackFormatName name,
                                    TypeDescriptor channelType)
-      : name_(name), typeDescriptor_(channelType) {
+      : name_(std::move(name)), typeDescriptor_(channelType) {
   }
 
 

--- a/src/elements/audio_programme.cpp
+++ b/src/elements/audio_programme.cpp
@@ -91,9 +91,9 @@ namespace adm {
     id_ = id;
   }
 
-  void AudioProgramme::set(AudioProgrammeName name) { name_ = name; }
+  void AudioProgramme::set(AudioProgrammeName name) { name_ = std::move(name); }
   void AudioProgramme::set(AudioProgrammeLanguage language) {
-    language_ = language;
+    language_ = std::move(language);
   }
   void AudioProgramme::set(Start start) { start_ = start; }
   void AudioProgramme::set(End end) { end_ = end; }
@@ -195,5 +195,6 @@ namespace adm {
     return audioProgrammeCopy;
   }
 
-  AudioProgramme::AudioProgramme(AudioProgrammeName name) : name_(name){};
+  AudioProgramme::AudioProgramme(AudioProgrammeName name)
+      : name_(std::move(name)){};
 }  // namespace adm

--- a/src/elements/audio_stream_format.cpp
+++ b/src/elements/audio_stream_format.cpp
@@ -34,7 +34,9 @@ namespace adm {
     }
     id_ = id;
   }
-  void AudioStreamFormat::set(AudioStreamFormatName name) { name_ = name; }
+  void AudioStreamFormat::set(AudioStreamFormatName name) {
+    name_ = std::move(name);
+  }
 
   // ---- Has ---- //
   bool AudioStreamFormat::has(
@@ -200,7 +202,7 @@ namespace adm {
 
   AudioStreamFormat::AudioStreamFormat(AudioStreamFormatName name,
                                        FormatDescriptor format)
-      : name_(name),
+      : name_(std::move(name)),
         id_(AudioStreamFormatId(TypeDefinition::UNDEFINED)),
         format_(format) {}
 

--- a/src/elements/audio_track_format.cpp
+++ b/src/elements/audio_track_format.cpp
@@ -33,7 +33,9 @@ namespace adm {
     }
     id_ = id;
   }
-  void AudioTrackFormat::set(AudioTrackFormatName name) { name_ = name; }
+  void AudioTrackFormat::set(AudioTrackFormatName name) {
+    name_ = std::move(name);
+  }
 
   // ---- Has ---- //
   bool AudioTrackFormat::has(
@@ -132,7 +134,7 @@ namespace adm {
 
   AudioTrackFormat::AudioTrackFormat(AudioTrackFormatName name,
                                      FormatDescriptor format)
-      : name_(name),
+      : name_(std::move(name)),
         id_(AudioTrackFormatId(TypeDefinition::UNDEFINED)),
         format_(format) {}
 

--- a/src/private/xml_parser.cpp
+++ b/src/private/xml_parser.cpp
@@ -159,7 +159,7 @@ namespace adm {
       if(idMap_.contains(id)) {
         throw error::XmlParsingDuplicateId(formatId(id), getDocumentLine(node));
       }
-      auto audioProgramme = AudioProgramme::create(name, id);
+      auto audioProgramme = AudioProgramme::create(std::move(name), id);
 
       setOptionalAttribute<AudioProgrammeLanguage>(node, "audioProgrammeLanguage", audioProgramme);
       setOptionalAttribute<Start>(node, "start", audioProgramme, &parseTimecode);
@@ -183,7 +183,7 @@ namespace adm {
       if(idMap_.contains(id)) {
         throw error::XmlParsingDuplicateId(formatId(id), getDocumentLine(node));
       }
-      auto audioContent = AudioContent::create(name, id);
+      auto audioContent = AudioContent::create(std::move(name), id);
 
       setOptionalAttribute<AudioContentLanguage>(node, "audioContentLanguage", audioContent);
 
@@ -204,7 +204,7 @@ namespace adm {
       if(idMap_.contains(id)) {
         throw error::XmlParsingDuplicateId(formatId(id), getDocumentLine(node));
       }
-      auto audioObject = AudioObject::create(name, id);
+      auto audioObject = AudioObject::create(std::move(name), id);
 
       setOptionalAttribute<Start>(node, "start", audioObject, &parseTimecode);
       setOptionalAttribute<Duration>(node, "duration", audioObject, &parseTimecode);
@@ -314,14 +314,14 @@ namespace adm {
       checkChannelType(id, typeLabel, typeDefinition);
 
       if(typeDescriptor == adm::TypeDefinition::HOA){
-          auto audioPackFormat = AudioPackFormatHoa::create(name, id);
+          auto audioPackFormat = AudioPackFormatHoa::create(std::move(name), id);
           setCommonProperties(audioPackFormat, node);
           setOptionalAttribute<Normalization>(node, "normalization", audioPackFormat);
           setOptionalAttribute<ScreenRef>(node, "screenRef", audioPackFormat);
           setOptionalAttribute<NfcRefDist>(node, "nfcRefDist", audioPackFormat);
           return audioPackFormat;
       } else {
-          auto audioPackFormat = AudioPackFormat::create(name, typeDescriptor, id);
+          auto audioPackFormat = AudioPackFormat::create(std::move(name), typeDescriptor, id);
           setCommonProperties(audioPackFormat, node);
           return audioPackFormat;
       }
@@ -346,7 +346,7 @@ namespace adm {
       if(idMap_.contains(id)) {
         throw error::XmlParsingDuplicateId(formatId(id), getDocumentLine(node));
       }
-      auto audioChannelFormat = AudioChannelFormat::create(name, id.get<TypeDescriptor>(), id);
+      auto audioChannelFormat = AudioChannelFormat::create(std::move(name), id.get<TypeDescriptor>(), id);
 
       auto typeLabel = parseOptionalAttribute<TypeDescriptor>(node, "typeLabel", &parseTypeLabel);
       auto typeDefinition = parseOptionalAttribute<TypeDescriptor>(node, "typeDefinition", &parseTypeDefinition);
@@ -398,7 +398,7 @@ namespace adm {
       auto formatLabel = parseOptionalAttribute<FormatDescriptor>(node, "formatLabel", &parseFormatLabel);
       auto formatDefinition = parseOptionalAttribute<FormatDescriptor>(node, "formatDefinition", &parseFormatDefinition);
       auto format = checkFormat(formatLabel, formatDefinition);
-      auto audioStreamFormat = AudioStreamFormat::create(name, format, id);
+      auto audioStreamFormat = AudioStreamFormat::create(std::move(name), format, id);
 
       setOptionalReference<AudioChannelFormatId>(node, "audioChannelFormatIDRef", audioStreamFormat, streamFormatChannelFormatRef_, &parseAudioChannelFormatId);
       setOptionalReference<AudioPackFormatId>(node, "audioPackFormatIDRef", audioStreamFormat, streamFormatPackFormatRef_, &parseAudioPackFormatId);
@@ -420,7 +420,7 @@ namespace adm {
       auto formatDefinition = parseOptionalAttribute<FormatDescriptor>(node, "formatDefinition", &parseFormatDefinition);
       auto format = checkFormat(formatLabel, formatDefinition);
 
-      auto audioTrackFormat = AudioTrackFormat::create(name, format, id);
+      auto audioTrackFormat = AudioTrackFormat::create(std::move(name), format, id);
 
       setOptionalReference<AudioStreamFormatId>(node, "audioStreamFormatIDRef", audioTrackFormat, trackFormatStreamFormatRef_, &parseAudioStreamFormatId);
       // clang-format on

--- a/tests/auto_base_tests.cpp
+++ b/tests/auto_base_tests.cpp
@@ -48,8 +48,7 @@ namespace adm {
   struct TestElement : private detail::Base {
     template <typename... Parameters>
     explicit TestElement(Parameters... namedArgs) {
-      detail::setNamedOptionHelper(this,
-                                   std::forward<Parameters>(namedArgs)...);
+      detail::setNamedOptionHelper(this, std::move(namedArgs)...);
     }
 
     using detail::Base::add;


### PR DESCRIPTION
This fixes #121, pretty much just because it's wrong with little real-world benefit. The use of `disableIfCopy` is explained in the first commit.

After doing that i found a load more situations where strings can be moved rather than copied. This does seem worthwhile -- when running xml_parser_common_definitions_tests (which just parses common definitions and a simple document), about 1000 allocations (presumably string copies) are saved.