### PR TITLE
support absolute directories in ADM_INSTALL_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - implemented fractional time format from BS.2076-2
 - audioProgramme and audioContent may now have multiple loudnessMetadata elements, as per BS.2076-2
 - admConfig.cmake updated to behave better with find_package calls - errors are now reported correctly and info messages are silenced if QUIET has been requested.
+- libadm_INCLUDE_DIRS and libadm_LIBRARY_DIRS were removed from admConfig.cmake. Users of these should link to the adm targets instead, as per the documentation.
 - CMake GNUInstallDirs module used to determine default install locations
 - INSTALL_XXX_DIR cache variables prefixed with ADM
 - Install path for .dll on Windows changed to binary dir 

--- a/config/admConfig.cmake.in
+++ b/config/admConfig.cmake.in
@@ -2,9 +2,6 @@ include(CMakeFindDependencyMacro)
 
 @PACKAGE_INIT@
 
-set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@ADM_INSTALL_INCLUDE_DIR@")
-set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/@ADM_INSTALL_LIB_DIR@")
-
 find_dependency(Boost 1.57)
 
 set(errorVar ${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE)


### PR DESCRIPTION
Since 56e7bc512823eb83b8ad48c24cbd3c41e817f4b0, the CMAKE_INSTALL_*
variables are used to set the install paths, however these are allowed
to be absolute paths, and this causes libadm_*DIRS to be set incorrectly
(to two concatenated absolute paths).

Fix this behaviour using GNUInstallDirs_get_absolute_install_dir, which
gives the same behaviour as just using CMAKE_INSTALL_* dirs directly.

This is useful mainly for split distribution packaging, where
development and run-time components are installed to completely separate
output directories