### PR TITLE
Fix warnings

### DIFF
--- a/include/adm/detail/id_map.hpp
+++ b/include/adm/detail/id_map.hpp
@@ -8,7 +8,7 @@ namespace adm {
     ///
     /// the value is given by the template T, so that get<AudioProgramme>()
     /// returns a T<AudioProgramme>, for example
-    template <template <typename Element> typename T>
+    template <template <typename Element> class T>
     struct ForEachElement {
       /// get one of the stored values
       template <typename El>

--- a/include/adm/private/rapidxml_utils.hpp
+++ b/include/adm/private/rapidxml_utils.hpp
@@ -7,7 +7,7 @@ namespace adm {
   namespace xml {
     template <typename It>
     int countLines(It begin, It end) {
-      return std::count(begin, end, '\n');
+      return static_cast<int>(std::count(begin, end, '\n'));
     }
 
     inline int getDocumentLine(rapidxml::xml_node<>* node) {

--- a/submodules/rapidxml/rapidxml_print.hpp
+++ b/submodules/rapidxml/rapidxml_print.hpp
@@ -190,7 +190,7 @@ namespace rapidxml
 
         // Print attributes of the node
         template<class OutIt, class Ch>
-        inline OutIt print_attributes(OutIt out, const xml_node<Ch> *node, int flags)
+        inline OutIt print_attributes(OutIt out, const xml_node<Ch> *node, int /*flags*/)
         {
             for (xml_attribute<Ch> *attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute())
             {

--- a/tests/enum_bitmask_options_tests.cpp
+++ b/tests/enum_bitmask_options_tests.cpp
@@ -29,31 +29,31 @@ TEST_CASE("bitmask_operators") {
   using adm::TestOptions;
   {
     TestOptions opt = TestOptions::secure | TestOptions::verbose;
-    REQUIRE(unsigned(opt) == (0x1 | 0x4));
+    REQUIRE(unsigned(opt) == (0x1u | 0x4u));
   }
   {
     TestOptions opt = TestOptions::secure;
     opt |= TestOptions::verbose;
-    REQUIRE(unsigned(opt) == (0x1 | 0x4));
+    REQUIRE(unsigned(opt) == (0x1u | 0x4u));
   }
   {
     TestOptions opt =
         TestOptions::verbose & (TestOptions::secure | TestOptions::verbose);
-    REQUIRE(unsigned(opt) == (0x4 & (0x1 | 0x4)));
+    REQUIRE(unsigned(opt) == (0x4u & (0x1u | 0x4u)));
   }
   {
     TestOptions opt = (TestOptions::secure | TestOptions::verbose);
     opt &= TestOptions::verbose;
-    REQUIRE(unsigned(opt) == (0x4 & (0x1 | 0x4)));
+    REQUIRE(unsigned(opt) == (0x4u & (0x1u | 0x4u)));
   }
   {
     TestOptions opt = (TestOptions::secure | TestOptions::verbose);
     opt ^= TestOptions::verbose;
-    REQUIRE(unsigned(opt) == (0x4 ^ (0x1 | 0x4)));
+    REQUIRE(unsigned(opt) == (0x4u ^ (0x1u | 0x4u)));
   }
   {
     TestOptions opt = ~TestOptions::secure;
-    REQUIRE(unsigned(opt) == (~0x1));
+    REQUIRE(unsigned(opt) == (~0x1u));
   }
 }
 

--- a/tests/route_tracer_tests.cpp
+++ b/tests/route_tracer_tests.cpp
@@ -31,43 +31,42 @@ TEST_CASE("basic") {
 // programme->content->object->trackuid->trackformat->streamformat->channelformat
 struct FullDepthViaUIDStrategy {
   template <typename SubElement, typename Element>
-  bool shouldRecurse(std::shared_ptr<Element> a,
-                     std::shared_ptr<SubElement> b) {
+  bool shouldRecurse(std::shared_ptr<Element>, std::shared_ptr<SubElement>) {
     return false;
   }
 
-  bool shouldRecurse(std::shared_ptr<const adm::AudioProgramme> a,
-                     std::shared_ptr<const adm::AudioContent> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioProgramme>,
+                     std::shared_ptr<const adm::AudioContent>) {
     return true;
   }
-  bool shouldRecurse(std::shared_ptr<const adm::AudioContent> a,
-                     std::shared_ptr<const adm::AudioObject> b) {
-    return true;
-  }
-
-  bool shouldRecurse(std::shared_ptr<const adm::AudioObject> a,
-                     std::shared_ptr<const adm::AudioObject> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioContent>,
+                     std::shared_ptr<const adm::AudioObject>) {
     return true;
   }
 
-  bool shouldRecurse(std::shared_ptr<const adm::AudioObject> a,
-                     std::shared_ptr<const adm::AudioTrackUid> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioObject>,
+                     std::shared_ptr<const adm::AudioObject>) {
     return true;
   }
-  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackUid> a,
-                     std::shared_ptr<const adm::AudioTrackFormat> b) {
+
+  bool shouldRecurse(std::shared_ptr<const adm::AudioObject>,
+                     std::shared_ptr<const adm::AudioTrackUid>) {
     return true;
   }
-  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackFormat> a,
-                     std::shared_ptr<const adm::AudioStreamFormat> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackUid>,
+                     std::shared_ptr<const adm::AudioTrackFormat>) {
     return true;
   }
-  bool shouldRecurse(std::shared_ptr<const adm::AudioStreamFormat> a,
-                     std::shared_ptr<const adm::AudioChannelFormat> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackFormat>,
+                     std::shared_ptr<const adm::AudioStreamFormat>) {
     return true;
   }
-  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackUid> a,
-                     std::shared_ptr<const adm::AudioChannelFormat> b) {
+  bool shouldRecurse(std::shared_ptr<const adm::AudioStreamFormat>,
+                     std::shared_ptr<const adm::AudioChannelFormat>) {
+    return true;
+  }
+  bool shouldRecurse(std::shared_ptr<const adm::AudioTrackUid>,
+                     std::shared_ptr<const adm::AudioChannelFormat>) {
     return true;
   }
 
@@ -77,7 +76,7 @@ struct FullDepthViaUIDStrategy {
   }
 
   template <typename Element>
-  bool isEndOfRoute(std::shared_ptr<Element> e) {
+  bool isEndOfRoute(std::shared_ptr<Element>) {
     return false;
   }
 


### PR DESCRIPTION
fix a few warnings when compiling with gcc and clang

This misses a few warnings like this from gcc (not clang):

```
/home/thomasn/dev/audio/libadm/src/private/rapidxml_formatter.cpp:36:24: warning: ‘*((void*)(& cartesianPosition)+20).adm::detail::NamedType<float, adm::ZOffsetTag>::value_’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   36 |           node.setValue(element.get());
      |           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/home/thomasn/dev/audio/libadm/src/private/rapidxml_formatter.cpp:565:14: note: ‘*((void*)(& cartesianPosition)+20).adm::detail::NamedType<float, adm::ZOffsetTag>::value_’ was declared here
  565 |         auto cartesianPosition =
      |              ^~~~~~~~~~~~~~~~~
```

I can't quite figure out the cause of this. `boost::optional<T>::get` just asserts that there is a value (doesn't throw an exception), so `PositionOffset::get<ZOffset>` can return an uninitialised value, but this code doesn't return unless `has` returns true, so that never happens.

I suspect the compiler just gives up trying to work out what's happening in this specific case (lots of templates). Throwing an exception in `OptionalParameter::get` if the optional is empty seems to solve this, and would probably be a good idea, but it's a fairly big change to apply this to the non-auto-base types too.