### PR TITLE
remove trailing zeros from times up to 5dp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Decimal times are now written without trailing zeros past 5 decimal places. To interoperate with ADM parsers which don't support more than 5 digits, users should round times in the ADM document before writing.
+
 ## 0.14.0 (September 12, 2022)
 
 ### Added

--- a/src/elements/time.cpp
+++ b/src/elements/time.cpp
@@ -94,7 +94,18 @@ namespace adm {
       ss << std::setw(2) << std::setfill('0')
          << std::chrono::duration_cast<std::chrono::seconds>(time).count() % 60;
       ss << ".";
-      ss << std::setw(9) << std::setfill('0') << time.count() % 1000000000;
+
+      {
+        auto ns = time.count() % 1000000000;
+        // drop trailing zero digits, while keeping at least 5 to satisfy BS.2076-2
+        int precision = 9;
+        while (ns % 10 == 0 && precision > 5) {
+          ns /= 10;
+          precision--;
+        }
+        ss << std::setw(precision) << std::setfill('0') << ns;
+      }
+
       return ss.str();
     }
 

--- a/tests/adm_time_tests.cpp
+++ b/tests/adm_time_tests.cpp
@@ -43,7 +43,9 @@ TEST_CASE("adm_time") {
   // reformat timecode
   {
     REQUIRE(formatTimecode(parseTimecode("00:00:00.00000")) ==
-            "00:00:00.000000000");
+            "00:00:00.00000");
+    REQUIRE(formatTimecode(parseTimecode("00:00:00.000001")) ==
+            "00:00:00.000001");
     REQUIRE(formatTimecode(parseTimecode("04:20:14.046079001")) ==
             "04:20:14.046079001");
     REQUIRE(formatTimecode(parseTimecode("23:59:59.999999999")) ==

--- a/tests/test_data/loudness_metadata.accepted.xml
+++ b/tests/test_data/loudness_metadata.accepted.xml
@@ -3,7 +3,7 @@
 	<coreMetadata>
 		<format>
 			<audioFormatExtended>
-				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="MyProgramme" audioProgrammeLanguage="en" start="00:00:00.000000000" end="00:00:10.000000000" maxDuckingDepth="-15.000000">
+				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="MyProgramme" audioProgrammeLanguage="en" start="00:00:00.00000" end="00:00:10.00000" maxDuckingDepth="-15.000000">
 					<loudnessMetadata loudnessMethod="ITU-R BS.1770" loudnessRecType="EBU R128" loudnessCorrectionType="File-based">
 						<integratedLoudness>-23.000000</integratedLoudness>
 						<loudnessRange>10.000000</loudnessRange>

--- a/tests/test_data/simple_scene_default.accepted.xml
+++ b/tests/test_data/simple_scene_default.accepted.xml
@@ -3,7 +3,7 @@
 	<coreMetadata>
 		<format>
 			<audioFormatExtended>
-				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.000000000" end="10:00:10.000000000">
+				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.00000" end="10:00:10.00000">
 					<audioContentIDRef>ACO_1001</audioContentIDRef>
 				</audioProgramme>
 				<audioContent audioContentID="ACO_1001" audioContentName="Main">
@@ -17,21 +17,21 @@
 					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
 				</audioPackFormat>
 				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="MainObject" typeLabel="0003" typeDefinition="Objects">
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.00000">
 						<position coordinate="azimuth">30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<jumpPosition>1</jumpPosition>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.00000">
 						<position coordinate="azimuth">-30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<jumpPosition interpolationLength="1.00000">1</jumpPosition>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.00000">
 						<position coordinate="azimuth">0.000000</position>
 						<position coordinate="elevation">0.000000</position>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.00000">
 						<position coordinate="azimuth">30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 					</audioBlockFormat>

--- a/tests/test_data/simple_scene_itu.accepted.xml
+++ b/tests/test_data/simple_scene_itu.accepted.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ituADM>
 	<audioFormatExtended>
-		<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.000000000" end="10:00:10.000000000">
+		<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.00000" end="10:00:10.00000">
 			<audioContentIDRef>ACO_1001</audioContentIDRef>
 		</audioProgramme>
 		<audioContent audioContentID="ACO_1001" audioContentName="Main">
 			<audioObjectIDRef>AO_1001</audioObjectIDRef>
 		</audioContent>
-		<audioObject audioObjectID="AO_1001" audioObjectName="MainObject" start="00:00:00.000000000">
+		<audioObject audioObjectID="AO_1001" audioObjectName="MainObject" start="00:00:00.00000">
 			<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
 			<audioTrackUIDRef>ATU_00000001</audioTrackUIDRef>
 			<gain>1.000000</gain>
@@ -18,7 +18,7 @@
 			<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
 		</audioPackFormat>
 		<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="MainObject" typeLabel="0003" typeDefinition="Objects">
-			<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.000000000">
+			<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.00000">
 				<position coordinate="azimuth">30.000000</position>
 				<position coordinate="elevation">0.000000</position>
 				<position coordinate="distance">1.000000</position>
@@ -36,7 +36,7 @@
 				<headphoneVirtualise bypass="0" DRR="130.000000"/>
 				<importance>10</importance>
 			</audioBlockFormat>
-			<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.000000000">
+			<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.00000">
 				<position coordinate="azimuth">-30.000000</position>
 				<position coordinate="elevation">0.000000</position>
 				<position coordinate="distance">1.000000</position>
@@ -54,7 +54,7 @@
 				<headphoneVirtualise bypass="0" DRR="130.000000"/>
 				<importance>10</importance>
 			</audioBlockFormat>
-			<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.000000000">
+			<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.00000">
 				<position coordinate="azimuth">0.000000</position>
 				<position coordinate="elevation">0.000000</position>
 				<position coordinate="distance">1.000000</position>
@@ -72,7 +72,7 @@
 				<headphoneVirtualise bypass="0" DRR="130.000000"/>
 				<importance>10</importance>
 			</audioBlockFormat>
-			<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.000000000">
+			<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.00000">
 				<position coordinate="azimuth">30.000000</position>
 				<position coordinate="elevation">0.000000</position>
 				<position coordinate="distance">1.000000</position>

--- a/tests/test_data/write_audio_programme.accepted.xml
+++ b/tests/test_data/write_audio_programme.accepted.xml
@@ -3,7 +3,7 @@
 	<coreMetadata>
 		<format>
 			<audioFormatExtended>
-				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="MyProgramme" audioProgrammeLanguage="de" start="00:00:00.000000000" end="00:00:10.000000000" maxDuckingDepth="-30.000000">
+				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="MyProgramme" audioProgrammeLanguage="de" start="00:00:00.00000" end="00:00:10.00000" maxDuckingDepth="-30.000000">
 					<audioProgrammeLabel language="en">My Programme</audioProgrammeLabel>
 					<audioProgrammeLabel language="deu">Mein Programm</audioProgrammeLabel>
 				</audioProgramme>

--- a/tests/test_data/write_object_attributes.accepted.xml
+++ b/tests/test_data/write_object_attributes.accepted.xml
@@ -3,7 +3,7 @@
 	<coreMetadata>
 		<format>
 			<audioFormatExtended>
-				<audioObject audioObjectID="AO_1001" audioObjectName="other parameters" start="00:00:00.000000000" duration="00:00:10.000000000" dialogue="1" importance="5" interact="1" disableDucking="1">
+				<audioObject audioObjectID="AO_1001" audioObjectName="other parameters" start="00:00:00.00000" duration="00:00:10.00000" dialogue="1" importance="5" interact="1" disableDucking="1">
 					<audioObjectLabel>label</audioObjectLabel>
 					<gain>0.500000</gain>
 					<headLocked>1</headLocked>

--- a/tests/test_data/write_optional_defaults.accepted.xml
+++ b/tests/test_data/write_optional_defaults.accepted.xml
@@ -3,13 +3,13 @@
 	<coreMetadata>
 		<format>
 			<audioFormatExtended>
-				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.000000000" end="10:00:10.000000000">
+				<audioProgramme audioProgrammeID="APR_1001" audioProgrammeName="Main" start="10:00:00.00000" end="10:00:10.00000">
 					<audioContentIDRef>ACO_1001</audioContentIDRef>
 				</audioProgramme>
 				<audioContent audioContentID="ACO_1001" audioContentName="Main">
 					<audioObjectIDRef>AO_1001</audioObjectIDRef>
 				</audioContent>
-				<audioObject audioObjectID="AO_1001" audioObjectName="MainObject" start="00:00:00.000000000">
+				<audioObject audioObjectID="AO_1001" audioObjectName="MainObject" start="00:00:00.00000">
 					<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
 					<audioTrackUIDRef>ATU_00000001</audioTrackUIDRef>
 					<gain>1.000000</gain>
@@ -20,7 +20,7 @@
 					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
 				</audioPackFormat>
 				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="MainObject" typeLabel="0003" typeDefinition="Objects">
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:00.00000">
 						<position coordinate="azimuth">30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<position coordinate="distance">1.000000</position>
@@ -38,7 +38,7 @@
 						<headphoneVirtualise bypass="0" DRR="130.000000"/>
 						<importance>10</importance>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000002" rtime="00:00:03.00000">
 						<position coordinate="azimuth">-30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<position coordinate="distance">1.000000</position>
@@ -56,7 +56,7 @@
 						<headphoneVirtualise bypass="0" DRR="130.000000"/>
 						<importance>10</importance>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000003" rtime="00:00:06.00000">
 						<position coordinate="azimuth">0.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<position coordinate="distance">1.000000</position>
@@ -74,7 +74,7 @@
 						<headphoneVirtualise bypass="0" DRR="130.000000"/>
 						<importance>10</importance>
 					</audioBlockFormat>
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000004" rtime="00:00:09.00000">
 						<position coordinate="azimuth">30.000000</position>
 						<position coordinate="elevation">0.000000</position>
 						<position coordinate="distance">1.000000</position>

--- a/tests/test_data/write_partially_specified_cartesian.accepted.xml
+++ b/tests/test_data/write_partially_specified_cartesian.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="Test" typeLabel="0003" typeDefinition="Objects">
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:01.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:01.00000" duration="00:00:01.00000">
 						<position coordinate="X">0.000000</position>
 						<position coordinate="Y">0.000000</position>
 						<cartesian>1</cartesian>

--- a/tests/test_data/write_partially_specified_spherical.accepted.xml
+++ b/tests/test_data/write_partially_specified_spherical.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="Test" typeLabel="0003" typeDefinition="Objects">
-					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:01.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00031001_00000001" rtime="00:00:01.00000" duration="00:00:01.00000">
 						<position coordinate="azimuth">60.000000</position>
 						<position coordinate="elevation">30.000000</position>
 					</audioBlockFormat>

--- a/tests/test_data/write_specified_HOA_block.accepted.xml
+++ b/tests/test_data/write_specified_HOA_block.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00041001" audioChannelFormatName="Test" typeLabel="0004" typeDefinition="HOA">
-					<audioBlockFormat audioBlockFormatID="AB_00041001_00000001" rtime="00:00:00.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00041001_00000001" rtime="00:00:00.00000" duration="00:00:01.00000">
 						<order>2</order>
 						<degree>1</degree>
 						<nfcRefDist>2.000000</nfcRefDist>

--- a/tests/test_data/write_specified_binaural_block.accepted.xml
+++ b/tests/test_data/write_specified_binaural_block.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00051001" audioChannelFormatName="Test" typeLabel="0005" typeDefinition="Binaural">
-					<audioBlockFormat audioBlockFormatID="AB_00051001_00000001" rtime="00:00:00.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00051001_00000001" rtime="00:00:00.00000" duration="00:00:01.00000">
 						<gain>0.500000</gain>
 						<importance>5</importance>
 					</audioBlockFormat>

--- a/tests/test_data/write_specified_cartesian_speaker.accepted.xml
+++ b/tests/test_data/write_specified_cartesian_speaker.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00011001" audioChannelFormatName="Test" typeLabel="0001" typeDefinition="DirectSpeakers">
-					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001" rtime="00:00:01.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001" rtime="00:00:01.00000" duration="00:00:01.00000">
 						<speakerLabel>testLabel</speakerLabel>
 						<position coordinate="X" screenEdgeLock="left">0.000000</position>
 						<position coordinate="X" bound="min">-0.100000</position>

--- a/tests/test_data/write_specified_spherical_speaker.accepted.xml
+++ b/tests/test_data/write_specified_spherical_speaker.accepted.xml
@@ -4,7 +4,7 @@
 		<format>
 			<audioFormatExtended>
 				<audioChannelFormat audioChannelFormatID="AC_00011001" audioChannelFormatName="Test" typeLabel="0001" typeDefinition="DirectSpeakers">
-					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001" rtime="00:00:01.000000000" duration="00:00:01.000000000">
+					<audioBlockFormat audioBlockFormatID="AB_00011001_00000001" rtime="00:00:01.00000" duration="00:00:01.00000">
 						<speakerLabel>testLabel</speakerLabel>
 						<position coordinate="azimuth" screenEdgeLock="left">60.000000</position>
 						<position coordinate="azimuth" bound="min">58.000000</position>


### PR DESCRIPTION
Decimal times are now written without trailing zeros past 5 decimal places. To interoperate with ADM parsers which don't support more than 5 digits, users should round times in the ADM document before writing.

closes #168