### PR TITLE
Fix parsing complementary objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - Decimal times are now written without trailing zeros past 5 decimal places. To interoperate with ADM parsers which don't support more than 5 digits, users should round times in the ADM document before writing.
 
+### Fixed
+- Complementary audio object references are now read by the xml parser.
+
 ## 0.14.0 (September 12, 2022)
 
 ### Added

--- a/include/adm/private/xml_parser.hpp
+++ b/include/adm/private/xml_parser.hpp
@@ -103,6 +103,7 @@ namespace adm {
       std::map<std::shared_ptr<AudioProgramme>, std::vector<AudioContentId>> programmeContentRefs_;
       std::map<std::shared_ptr<AudioContent>, std::vector<AudioObjectId>> contentObjectRefs_;
       std::map<std::shared_ptr<AudioObject>, std::vector<AudioObjectId>> objectObjectRefs_;
+      std::map<std::shared_ptr<AudioObject>, std::vector<AudioObjectId>> objectComplementaryObjectRefs_;
       std::map<std::shared_ptr<AudioObject>, std::vector<AudioPackFormatId>> objectPackFormatRefs_;
       std::map<std::shared_ptr<AudioObject>, std::vector<AudioTrackUidId>> objectTrackUidRefs_;
       std::map<std::shared_ptr<AudioTrackUid>, AudioTrackFormatId> trackUidTrackFormatRef_;

--- a/src/private/xml_parser.cpp
+++ b/src/private/xml_parser.cpp
@@ -81,6 +81,16 @@ namespace adm {
         resolveReferences(programmeContentRefs_);
         resolveReferences(contentObjectRefs_);
         resolveReferences(objectObjectRefs_);
+        // resolve complementary object references
+        for (auto& entry : objectComplementaryObjectRefs_) {
+          for (const auto& id : entry.second) {
+            if (auto element = document_->lookup(id)) {
+                entry.first->addComplementary(element);
+            } else {
+              throw error::XmlParsingUnresolvedReference(formatId(id));
+            }
+          }
+        }
         resolveReferences(objectPackFormatRefs_);
         resolveTrackUidReferences(objectTrackUidRefs_);
         resolveReference(trackUidTrackFormatRef_);
@@ -214,6 +224,7 @@ namespace adm {
       setOptionalAttribute<DisableDucking>(node, "disableDucking", audioObject);
 
       addOptionalReferences<AudioObjectId>(node, "audioObjectIDRef", audioObject, objectObjectRefs_, &parseAudioObjectId);
+      addOptionalReferences<AudioObjectId>(node, "audioComplementaryObjectIDRef", audioObject, objectComplementaryObjectRefs_, &parseAudioObjectId);
       addOptionalReferences<AudioPackFormatId>(node, "audioPackFormatIDRef", audioObject, objectPackFormatRefs_, &parseAudioPackFormatId);
       addOptionalReferences<AudioTrackUidId>(node, "audioTrackUIDRef", audioObject, objectTrackUidRefs_, &parseAudioTrackUidId);
       setOptionalElement<AudioObjectInteraction>(node, "audioObjectInteraction", audioObject, &parseAudioObjectInteraction);

--- a/tests/test_data/xml_parser/audio_object_complementary_audio_objects.xml
+++ b/tests/test_data/xml_parser/audio_object_complementary_audio_objects.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ebuCoreMain xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="urn:ebu:metadata-schema:ebuCore_2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schema="EBU_CORE_20140201.xsd" xml:lang="en">
+	<coreMetadata>
+		<format>
+			<audioFormatExtended>
+				<audioObject audioObjectID="AO_1001" audioObjectName="Default">
+					<audioComplementaryObjectIDRef>AO_1002</audioComplementaryObjectIDRef>
+				</audioObject>
+				<audioObject audioObjectID="AO_1002" audioObjectName="Complementary"/>
+			</audioFormatExtended>
+		</format>
+	</coreMetadata>
+</ebuCoreMain>
+

--- a/tests/xml_parser_audio_object_tests.cpp
+++ b/tests/xml_parser_audio_object_tests.cpp
@@ -209,3 +209,15 @@ TEST_CASE("xml_parser/audio_object_track_refs") {
           0);
   REQUIRE(silentTrack->isSilent());
 }
+
+TEST_CASE("xml_parser/audio_object_complementary_audio_objects") {
+  using namespace adm;
+  auto document = parseXml("xml_parser/audio_object_complementary_audio_objects.xml");
+
+  auto audioObjectDefault = document->lookup(parseAudioObjectId("AO_1001"));
+  auto audioObjectComplementary = document->lookup(parseAudioObjectId("AO_1002"));
+
+  auto complementaryObjects = audioObjectDefault->getComplementaryObjects();
+  REQUIRE(complementaryObjects.size() == 1);
+  REQUIRE(std::find(complementaryObjects.cbegin(), complementaryObjects.cend(), audioObjectComplementary) != complementaryObjects.cend());
+}


### PR DESCRIPTION
- fixed missing parsing of complementary objects.
- added a simple test
  - using a renamed duplicate of tests/test_data/write_complementary_audio_objects.accepted.xml