### PR TITLE
Support 2076-2-style structures in reassignIds

### DIFF
--- a/include/adm/detail/id_assigner.hpp
+++ b/include/adm/detail/id_assigner.hpp
@@ -9,7 +9,17 @@ namespace adm {
   class Document;
 
   namespace detail {
-
+    /**
+     * @brief Assigns a unique ID to elements.
+     *
+     * Works by using lookups to find the next available element 
+     * ID.
+     * 
+     * @note This class differs from IdReassigner in that it can
+     * function on a document which already has elements with ID's
+     * which you wish to maintain. However, the trade-off is that
+     * it is less efficient.
+     */
     class IdAssigner {
      public:
       ADM_EXPORT AudioProgrammeId assignId(AudioProgramme& programme);

--- a/include/adm/detail/id_assigner.hpp
+++ b/include/adm/detail/id_assigner.hpp
@@ -12,11 +12,10 @@ namespace adm {
     /**
      * @brief Assigns a unique ID to elements.
      *
-     * Works by using lookups to find the next available element 
-     * ID.
+     * Uses lookups to find the next available element ID. 
      * 
      * @note This class differs from IdReassigner in that it can
-     * function on a document which already has elements with ID's
+     * operate on a Document which already has elements with ID's
      * which you wish to maintain. However, the trade-off is that
      * it is less efficient.
      */

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -120,7 +120,8 @@ namespace adm {
       AudioContentId issueAudioContentId();
       AudioObjectId issueAudioObjectId();
       AudioTrackUidId issueAudioTrackUidId();
-      AudioPackFormatId issueAudioPackFormatId(const TypeDescriptor& typeDescriptor);
+      AudioPackFormatId issueAudioPackFormatId(
+          const TypeDescriptor& typeDescriptor);
       AudioChannelFormatId issueAudioChannelFormatId(
           const TypeDescriptor& typeDescriptor);
       uint16_t issueAudioChannelStreamTrackFormatIdValue(

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -4,6 +4,7 @@
 #include "adm/document.hpp"
 #include "adm/export.h"
 
+#include <map>
 #include <memory>
 
 namespace adm {
@@ -95,5 +96,49 @@ namespace adm {
     return (id == AudioBlockFormatId());
   }
   ///@}
+
+  class IdReassigner {
+   public:
+    IdReassigner(std::shared_ptr<Document> document);
+
+   private:
+    void reassignAllIds();
+
+    void reassignAudioProgrammeIds();
+    void reassignAudioContentIds();
+    void reassignAudioObjectIds();
+    void reassignAudioPackFormatIds();
+    void reassignAudioStreamFormatIds();
+    void reassignAudioTrackUidIds();
+    void reassignAudioBlockFormatIds(
+        std::shared_ptr<AudioChannelFormat> audioChannelFormat);
+
+    class IdIssuer {
+     public:
+      IdIssuer();
+      AudioProgrammeId issueAudioProgrammeId();
+      AudioContentId issueAudioContentId();
+      AudioObjectId issueAudioObjectId();
+      AudioTrackUidId issueAudioTrackUidId();
+      AudioPackFormatId issueAudioPackFormatId(TypeDescriptor typeDescriptor);
+      AudioChannelFormatId issueAudioChannelFormatId(
+          TypeDescriptor typeDescriptor);
+      uint16_t issueAudioChannelStreamTrackFormatIdValue(
+          TypeDescriptor typeDescriptor);
+
+     private:
+      AudioProgrammeIdValue nextAudioProgrammeIdValue{0x1001};
+      AudioContentIdValue nextAudioContentIdValue{0x1001};
+      AudioObjectIdValue nextAudioObjectIdValue{0x1001};
+      AudioTrackUidIdValue nextAudioTrackUidIdValue{0x00000001};
+      std::map<TypeDescriptor, AudioPackFormatIdValue>
+          nextAudioPackFormatIdValue;
+      std::map<TypeDescriptor, uint16_t>
+          nextAudioChannelStreamTrackFormatIdValue;
+
+    } idIssuer;
+
+    std::shared_ptr<Document> document;
+  };
 
 }  // namespace adm

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -11,19 +11,22 @@ namespace adm {
   /**
    * @brief Reassign ids of an Document
    *
-   * Assigns new ids to all the elements wihtin an Document. Unreferenced
-   * audioTrackFormats and audioChannelFormats which are not referenced by an
-   * audioStreamFormat get an Id with the value zero and are thereby marked as
+   * Assigns new IDs to all the elements wihtin an Document. 
+   * audioTrackFormats which are not referenced by an audioStreamFormat get an
+   * ID with the value zero and are thereby marked as ADM elements which
+   * should be ignored.
+   * audioChannelFormats which are not referenced by an audioStreamFormat or
+   * an audioTrackUid get an ID with the value zero and are thereby marked as
    * ADM elements which should be ignored.
    *
    * @note
-   * Element that already have Ids with a value in the range 0x0001-0x0fff
+   * Element that already have IDs with a value in the range 0x0001-0x0fff
    * will not get new Ids assigned, as they are considered to be common
    * definitions.
    */
   ADM_EXPORT void reassignIds(std::shared_ptr<Document> document);
 
-  /** @name Check if id is a common definitions id
+  /** @name Check if ID is a common definitions ID
    */
   ///@{
   inline bool isCommonDefinitionsId(AudioProgrammeId id) {
@@ -61,9 +64,9 @@ namespace adm {
   }
   ///@}
 
-  /** @name Check if id is undefined
+  /** @name Check if ID is undefined
    *
-   * An id is undefined if type, value and counter are 0u.
+   * An ID is undefined if type, value and counter are 0u.
    */
   ///@{
   inline bool isUndefined(AudioProgrammeId id) {

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -10,19 +10,19 @@
 namespace adm {
 
   /**
-   * @brief Reassign ids of an Document
+   * @brief Reassign ID's of a Document
    *
-   * Assigns new IDs to all the elements wihtin an Document. 
-   * audioTrackFormats which are not referenced by an audioStreamFormat get an
+   * Assigns new IDs to all the elements within an Document. 
+   * AudioTrackFormats which are not referenced by an AudioStreamFormat get an
    * ID with the value zero and are thereby marked as ADM elements which
    * should be ignored.
-   * audioChannelFormats which are not referenced by an audioStreamFormat or
-   * an audioTrackUid get an ID with the value zero and are thereby marked as
+   * AudioChannelFormats which are not referenced by an AudioStreamFormat or
+   * an AudioTrackUid get an ID with the value zero and are thereby marked as
    * ADM elements which should be ignored.
    *
    * @note
-   * Element that already have IDs with a value in the range 0x0001-0x0fff
-   * will not get new Ids assigned, as they are considered to be common
+   * Elements that already have ID's with a value in the range 0x0001-0x0fff
+   * will not get new ID's assigned, as they are considered to be common
    * definitions.
    */
   ADM_EXPORT void reassignIds(std::shared_ptr<Document> document);

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -97,48 +97,4 @@ namespace adm {
   }
   ///@}
 
-  class IdReassigner {
-   public:
-    IdReassigner(std::shared_ptr<Document> document);
-
-   private:
-    void reassignAllIds();
-
-    void reassignAudioProgrammeIds();
-    void reassignAudioContentIds();
-    void reassignAudioObjectIds();
-    void reassignAudioPackFormatIds();
-    void reassignAudioStreamFormatIds();
-    void reassignAudioTrackUidIds();
-    void reassignAudioBlockFormatIds(
-        std::shared_ptr<AudioChannelFormat> audioChannelFormat);
-
-    class IdIssuer {
-     public:
-      IdIssuer();
-      AudioProgrammeId issueAudioProgrammeId();
-      AudioContentId issueAudioContentId();
-      AudioObjectId issueAudioObjectId();
-      AudioTrackUidId issueAudioTrackUidId();
-      AudioPackFormatId issueAudioPackFormatId(
-          const TypeDescriptor& typeDescriptor);
-      AudioChannelFormatId issueAudioChannelFormatId(
-          const TypeDescriptor& typeDescriptor);
-      uint16_t issueAudioChannelStreamTrackFormatIdValue(
-          const TypeDescriptor& typeDescriptor);
-
-     private:
-      uint32_t nextAudioProgrammeIdValue{0x1001u};
-      uint32_t nextAudioContentIdValue{0x1001u};
-      uint32_t nextAudioObjectIdValue{0x1001u};
-      uint64_t nextAudioTrackUidIdValue{0x00000001u};
-      std::map<TypeDescriptor, uint32_t> nextAudioPackFormatIdValue;
-      std::map<TypeDescriptor, uint32_t>
-          nextAudioChannelStreamTrackFormatIdValue;
-
-    } idIssuer;
-
-    std::shared_ptr<Document> document;
-  };
-
 }  // namespace adm

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -128,13 +128,12 @@ namespace adm {
           const TypeDescriptor& typeDescriptor);
 
      private:
-      AudioProgrammeIdValue nextAudioProgrammeIdValue{0x1001};
-      AudioContentIdValue nextAudioContentIdValue{0x1001};
-      AudioObjectIdValue nextAudioObjectIdValue{0x1001};
-      AudioTrackUidIdValue nextAudioTrackUidIdValue{0x00000001};
-      std::map<TypeDescriptor, AudioPackFormatIdValue>
-          nextAudioPackFormatIdValue;
-      std::map<TypeDescriptor, uint16_t>
+      uint32_t nextAudioProgrammeIdValue{0x1001u};
+      uint32_t nextAudioContentIdValue{0x1001u};
+      uint32_t nextAudioObjectIdValue{0x1001u};
+      uint64_t nextAudioTrackUidIdValue{0x00000001u};
+      std::map<TypeDescriptor, uint32_t> nextAudioPackFormatIdValue;
+      std::map<TypeDescriptor, uint32_t>
           nextAudioChannelStreamTrackFormatIdValue;
 
     } idIssuer;

--- a/include/adm/utilities/id_assignment.hpp
+++ b/include/adm/utilities/id_assignment.hpp
@@ -120,11 +120,11 @@ namespace adm {
       AudioContentId issueAudioContentId();
       AudioObjectId issueAudioObjectId();
       AudioTrackUidId issueAudioTrackUidId();
-      AudioPackFormatId issueAudioPackFormatId(TypeDescriptor typeDescriptor);
+      AudioPackFormatId issueAudioPackFormatId(const TypeDescriptor& typeDescriptor);
       AudioChannelFormatId issueAudioChannelFormatId(
-          TypeDescriptor typeDescriptor);
+          const TypeDescriptor& typeDescriptor);
       uint16_t issueAudioChannelStreamTrackFormatIdValue(
-          TypeDescriptor typeDescriptor);
+          const TypeDescriptor& typeDescriptor);
 
      private:
       AudioProgrammeIdValue nextAudioProgrammeIdValue{0x1001};

--- a/include/adm/utilities/object_creation.hpp
+++ b/include/adm/utilities/object_creation.hpp
@@ -72,8 +72,9 @@ namespace adm {
    *
    * Creates an `AudioObject` including referenced `AudioPackFormat` and
    * `AudioChannelFormat` of type `TypeDefinition::OBJECTS`, as well an
-   * `AudioTrackUid`. This creates a shorter structure than 
-   * `createSimpleObject` as supported by 2076-2.
+   * `AudioTrackUid`. The audioTrackUID references the audioChannelFormat 
+   * directly, without an audioTrackFormat and audioStreamFormat, as 
+   * supported by BS.2076-2.
    *
    * @param name Name that will be used for the created
    * `Audio{Object,PackFormat,ChannelFormat}`.

--- a/include/adm/utilities/object_creation.hpp
+++ b/include/adm/utilities/object_creation.hpp
@@ -43,7 +43,7 @@ namespace adm {
   };
 
   /**
-   * @brief Create `AudioObject` hierarchie for single
+   * @brief Create `AudioObject` hierarchy for single
    * `TypeDefinition::OBJECTS`-type element
    *
    * Creates an `AudioObject` including referenced `AudioPackFormat` and
@@ -66,6 +66,30 @@ namespace adm {
   ADM_EXPORT SimpleObjectHolder addSimpleObjectTo(
       std::shared_ptr<Document> document, const std::string& name);
 
+  /**
+   * @brief Create `AudioObject` hierarchy for single
+   * `TypeDefinition::OBJECTS`-type element
+   *
+   * Creates an `AudioObject` including referenced `AudioPackFormat` and
+   * `AudioChannelFormat` of type `TypeDefinition::OBJECTS`, as well an
+   * `AudioTrackUid`. This creates a shorter structure than 
+   * `createSimpleObject` as supported by 2076-2.
+   *
+   * @param name Name that will be used for the created
+   * `Audio{Object,PackFormat,ChannelFormat}`.
+   */
+  ADM_EXPORT SimpleObjectHolder
+  createSimpleObjectShortStructure(const std::string& name);
+
+  /**
+   * @brief Create and add `AudioObject` hierarchy for single
+   * `TypeDefinition::OBJECTS`-type element
+   *
+   * same as `createSimpleObjectShortStructure`, but the elements 
+   * are automatically added to the given document
+   */
+  ADM_EXPORT SimpleObjectHolder addSimpleObjectShortStructureTo(
+      std::shared_ptr<Document> document, const std::string& name);
   /**
    * @brief Create and add `AudioObject` with common definitions direct speakers
    * channel bed to document

--- a/src/elements/audio_channel_format.cpp
+++ b/src/elements/audio_channel_format.cpp
@@ -54,7 +54,7 @@ namespace adm {
       assignNewIdValue<AudioBlockFormatBinaural>();
     } else {
       std::stringstream errorString;
-      errorString << "missmatch between TypeDefinition of AudioChannelFormat ("
+      errorString << "mismatch between TypeDefinition of AudioChannelFormat ("
                   << formatTypeDefinition(get<TypeDescriptor>())
                   << ") and AudioChannelFormatId ("
                   << formatTypeDefinition(id.get<TypeDescriptor>()) << ")";

--- a/src/elements/audio_pack_format.cpp
+++ b/src/elements/audio_pack_format.cpp
@@ -46,7 +46,7 @@ namespace adm {
       id_ = id;
     } else {
       std::stringstream errorString;
-      errorString << "missmatch between TypeDefinition of AudioPackFormat ("
+      errorString << "mismatch between TypeDefinition of AudioPackFormat ("
                   << formatTypeDefinition(get<TypeDescriptor>())
                   << ") and AudioPackFormatId ("
                   << formatTypeDefinition(id.get<TypeDescriptor>()) << ")";

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -104,12 +104,14 @@ namespace adm {
         continue;
       }
       auto typeDescriptor = audioChannelFormat->get<TypeDescriptor>();
-      auto idValue =
-          idIssuer.issueAudioChannelStreamTrackFormatIdValue(typeDescriptor);
+      uint16_t idValue = 0; // don't issue unless needed
 
       // AudioStreamFormat
       auto audioStreamFormatId = audioStreamFormat->get<AudioStreamFormatId>();
       if (!isCommonDefinitionsId(audioStreamFormatId)) {
+        if (idValue == 0)
+          idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
+              typeDescriptor);
         audioStreamFormatId.set(typeDescriptor);
         audioStreamFormatId.set(AudioStreamFormatIdValue{idValue});
         audioStreamFormat->set(audioStreamFormatId);
@@ -119,6 +121,9 @@ namespace adm {
       auto audioChannelFormatId =
           audioChannelFormat->get<AudioChannelFormatId>();
       if (!isCommonDefinitionsId(audioChannelFormatId)) {
+        if (idValue == 0)
+          idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
+              typeDescriptor);
         audioChannelFormatId.set(typeDescriptor);
         audioChannelFormatId.set(AudioChannelFormatIdValue{idValue});
         audioChannelFormat->set(audioChannelFormatId);
@@ -135,6 +140,9 @@ namespace adm {
         }
         auto audioTrackFormatId = audioTrackFormat->get<AudioTrackFormatId>();
         if (!isCommonDefinitionsId(audioTrackFormatId)) {
+          if (idValue == 0)
+          idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
+              typeDescriptor);
           audioTrackFormatId.set(typeDescriptor);
           audioTrackFormatId.set(AudioTrackFormatIdValue{idValue});
           audioTrackFormatId.set(audioTrackFormatIdCounter);

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -178,17 +178,19 @@ namespace adm {
       audioTrackUidId.set(audioTrackUidIdValue);
       audioTrackUid->set(audioTrackUidId);
       auto audioChannelFormat =
-          audioTrackUid->getReference<adm::AudioChannelFormat>();
+          audioTrackUid->template getReference<adm::AudioChannelFormat>();
       if (audioChannelFormat) {
         auto audioChannelFormatId =
             audioChannelFormat->template get<AudioChannelFormatId>();
         if (!isCommonDefinitionsId(audioChannelFormatId)) {
-          auto channelFormatType = audioChannelFormat->get<TypeDescriptor>();
+          auto channelFormatType =
+              audioChannelFormat->template get<TypeDescriptor>();
           auto doc = audioChannelFormat->getParent().lock();
           if (doc) {
             auto idValue = getAvailableIdValue(doc, channelFormatType);
+            AudioChannelFormatIdValue audioChannelFormatIdValue{idValue};
             audioChannelFormatId.set(channelFormatType);
-            audioChannelFormatId.set(AudioChannelFormatIdValue{idValue});
+            audioChannelFormatId.set(audioChannelFormatIdValue);
             audioChannelFormat->set(audioChannelFormatId);
             reassignAudioBlockFormatIds(audioChannelFormat);
           }

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -246,70 +246,39 @@ namespace adm {
     }
   }
 
+  namespace {
+    template <typename T>
+    void reassignBlockFormats(std::shared_ptr<AudioChannelFormat> const& acf) {
+      auto descriptor = acf->get<TypeDescriptor>();
+      auto idValue =
+          AudioBlockFormatIdValue(acf->get<AudioChannelFormatId>()
+                                      .get<AudioChannelFormatIdValue>()
+                                      .get());
+      auto idCounter = AudioBlockFormatIdCounter(0x00000001u);
+      for (auto& block : acf->getElements<T>()) {
+        auto id = block.template get<AudioBlockFormatId>();
+        id.set(descriptor);
+        id.set(idValue);
+        id.set(idCounter);
+        block.set(id);
+        ++idCounter;
+      }
+    }
+  }  // namespace
+
   void IdReassigner::reassignAudioBlockFormatIds(
       std::shared_ptr<AudioChannelFormat> audioChannelFormat) {
     auto typeDefinition = audioChannelFormat->get<TypeDescriptor>();
-    auto audioChannelFormatIdValue =
-        audioChannelFormat->get<AudioChannelFormatId>()
-            .get<AudioChannelFormatIdValue>();
-    auto audioBlockFormatIdValue =
-        AudioBlockFormatIdValue(audioChannelFormatIdValue.get());
-    auto audioBlockFormatIdCounter = AudioBlockFormatIdCounter(0x00000001u);
     if (typeDefinition == TypeDefinition::DIRECT_SPEAKERS) {
-      auto audioBlockFormats =
-          audioChannelFormat->getElements<AudioBlockFormatDirectSpeakers>();
-      for (auto& audioBlockFormat : audioBlockFormats) {
-        auto audioBlockFormatId = audioBlockFormat.get<AudioBlockFormatId>();
-        audioBlockFormatId.set(typeDefinition);
-        audioBlockFormatId.set(audioBlockFormatIdValue);
-        audioBlockFormatId.set(audioBlockFormatIdCounter);
-        audioBlockFormat.set(audioBlockFormatId);
-        ++audioBlockFormatIdCounter;
-      }
+      reassignBlockFormats<AudioBlockFormatDirectSpeakers>(audioChannelFormat);
     } else if (typeDefinition == TypeDefinition::MATRIX) {
-      auto audioBlockFormats =
-          audioChannelFormat->getElements<AudioBlockFormatMatrix>();
-      for (auto& audioBlockFormat : audioBlockFormats) {
-        auto audioBlockFormatId = audioBlockFormat.get<AudioBlockFormatId>();
-        audioBlockFormatId.set(typeDefinition);
-        audioBlockFormatId.set(audioBlockFormatIdValue);
-        audioBlockFormatId.set(audioBlockFormatIdCounter);
-        audioBlockFormat.set(audioBlockFormatId);
-        ++audioBlockFormatIdCounter;
-      }
+      reassignBlockFormats<AudioBlockFormatMatrix>(audioChannelFormat);
     } else if (typeDefinition == TypeDefinition::OBJECTS) {
-      auto audioBlockFormats =
-          audioChannelFormat->getElements<AudioBlockFormatObjects>();
-      for (auto& audioBlockFormat : audioBlockFormats) {
-        auto audioBlockFormatId = audioBlockFormat.get<AudioBlockFormatId>();
-        audioBlockFormatId.set(typeDefinition);
-        audioBlockFormatId.set(audioBlockFormatIdValue);
-        audioBlockFormatId.set(audioBlockFormatIdCounter);
-        audioBlockFormat.set(audioBlockFormatId);
-        ++audioBlockFormatIdCounter;
-      }
+      reassignBlockFormats<AudioBlockFormatObjects>(audioChannelFormat);
     } else if (typeDefinition == TypeDefinition::HOA) {
-      auto audioBlockFormats =
-          audioChannelFormat->getElements<AudioBlockFormatHoa>();
-      for (auto& audioBlockFormat : audioBlockFormats) {
-        auto audioBlockFormatId = audioBlockFormat.get<AudioBlockFormatId>();
-        audioBlockFormatId.set(typeDefinition);
-        audioBlockFormatId.set(audioBlockFormatIdValue);
-        audioBlockFormatId.set(audioBlockFormatIdCounter);
-        audioBlockFormat.set(audioBlockFormatId);
-        ++audioBlockFormatIdCounter;
-      }
+      reassignBlockFormats<AudioBlockFormatHoa>(audioChannelFormat);
     } else if (typeDefinition == TypeDefinition::BINAURAL) {
-      auto audioBlockFormats =
-          audioChannelFormat->getElements<AudioBlockFormatBinaural>();
-      for (auto& audioBlockFormat : audioBlockFormats) {
-        auto audioBlockFormatId = audioBlockFormat.get<AudioBlockFormatId>();
-        audioBlockFormatId.set(typeDefinition);
-        audioBlockFormatId.set(audioBlockFormatIdValue);
-        audioBlockFormatId.set(audioBlockFormatIdCounter);
-        audioBlockFormat.set(audioBlockFormatId);
-        ++audioBlockFormatIdCounter;
-      }
+      reassignBlockFormats<AudioBlockFormatBinaural>(audioChannelFormat);
     }
   }
 

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -153,6 +153,22 @@ namespace adm {
       auto audioTrackUidId = audioTrackUid->template get<AudioTrackUidId>();
       audioTrackUidId.set(audioTrackUidIdValue);
       audioTrackUid->set(audioTrackUidId);
+      auto audioChannelFormat =
+          audioTrackUid->getReference<adm::AudioChannelFormat>();
+      if (audioChannelFormat) {
+        auto audioChannelFormatId =
+            audioChannelFormat->template get<AudioChannelFormatId>();
+        if (!isCommonDefinitionsId(audioChannelFormatId)) {
+          auto channelFormatType =
+              audioChannelFormat->get<TypeDescriptor>();
+          auto channelFormatIdValue =
+              AudioChannelFormatIdValue(audioTrackUidIdValue.get() + 0x1000u); // non-common-def offset
+          audioChannelFormatId.set(channelFormatIdValue);
+          audioChannelFormatId.set(channelFormatType);
+          audioChannelFormat->set(audioChannelFormatId);
+          reassignAudioBlockFormatIds(audioChannelFormat);
+        }
+      }
       ++audioTrackUidIdValue;
     }
   }

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -24,12 +24,11 @@ namespace adm {
       AudioContentId issueAudioContentId();
       AudioObjectId issueAudioObjectId();
       AudioTrackUidId issueAudioTrackUidId();
-      AudioPackFormatId issueAudioPackFormatId(
-          const TypeDescriptor& typeDescriptor);
+      AudioPackFormatId issueAudioPackFormatId(TypeDescriptor typeDescriptor);
       AudioChannelFormatId issueAudioChannelFormatId(
-          const TypeDescriptor& typeDescriptor);
+          TypeDescriptor typeDescriptor);
       uint16_t issueAudioChannelStreamTrackFormatIdValue(
-          const TypeDescriptor& typeDescriptor);
+          TypeDescriptor typeDescriptor);
 
      private:
       uint32_t nextAudioProgrammeIdValue{0x1001u};
@@ -318,7 +317,7 @@ namespace adm {
   }
 
   AudioPackFormatId IdReassigner::IdIssuer::issueAudioPackFormatId(
-      const TypeDescriptor& typeDescriptor) {
+      TypeDescriptor typeDescriptor) {
     auto it = nextAudioPackFormatIdValue.emplace(typeDescriptor, 0x1001).first;
     if (it->second > 0xFFFFu)
       throw std::runtime_error("No AudioPackFormatId available");
@@ -329,7 +328,7 @@ namespace adm {
   }
 
   AudioChannelFormatId IdReassigner::IdIssuer::issueAudioChannelFormatId(
-      const TypeDescriptor& typeDescriptor) {
+      TypeDescriptor typeDescriptor) {
     auto it =
         nextAudioChannelStreamTrackFormatIdValue.emplace(typeDescriptor, 0x1001)
             .first;
@@ -341,7 +340,7 @@ namespace adm {
     return id;
   }
   uint16_t IdReassigner::IdIssuer::issueAudioChannelStreamTrackFormatIdValue(
-      const TypeDescriptor& typeDescriptor) {
+      TypeDescriptor typeDescriptor) {
     auto it =
         nextAudioChannelStreamTrackFormatIdValue.emplace(typeDescriptor, 0x1001)
             .first;

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -104,7 +104,8 @@ namespace adm {
         continue;
       }
       auto typeDescriptor = audioChannelFormat->get<TypeDescriptor>();
-      uint16_t idValue = 0;  // don't issue unless needed
+      uint16_t idValue =
+          0;  // don't issue unless needed - 0 (invalid) denotes unset
 
       // AudioStreamFormat
       auto audioStreamFormatId = audioStreamFormat->get<AudioStreamFormatId>();

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -285,11 +285,14 @@ namespace adm {
     /**
      * Initialize all audioTrackFormatIds and audioChanneldFormatIds to zero.
      * The reason behind this is, that the reassignAudioStreamFormatIds
-     * algorithm only gives new Ids to audioTrackFormats and
-     * audioChannelFormats which are referenced by a audioStreamFormat. This
-     * should be the right way to do it. Unreferenced elements will get an ID
-     * with value 0 and are thereby marked as elements which should be
-     * ignored.
+     * algorithm only gives new IDs to audioTrackFormats and
+     * audioChannelFormats which are referenced by an audioStreamFormat. 
+     * Additionally, audioStreamFormats are only given a valid ID if they 
+     * reference an audioChannelFormat. This should be the right way to do it 
+     * for 2076-0/1 structures. Unreferenced elements will get an ID with 
+     * value 0 and are thereby marked as elements which should be ignored.
+     * For 2076-2 structures, reassignAudioTrackUidIds will apply a unique ID
+     * to audioChannelFormats referenced directly from audioTrackUids.
      */
     undefineIds(document->template getElements<AudioTrackFormat>().begin(),
                 document->template getElements<AudioTrackFormat>().end());

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -12,6 +12,12 @@ namespace adm {
    * after being cleared and are therefore marked as elements to
    * be ignored.
    * 
+   * @note This class differs from IdAssigner in that it is more
+   * efficient for this purpose. IdAssigner uses lookups to find
+   * an available ID, which has exponential complexity. 
+   * IdReassigner uses the IdIssuer class to track ID's through
+   * simple incrementation and so has linear complexity.
+   * 
    * @param document Document that will have element ID's 
    * reassigned.
    */

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -258,7 +258,7 @@ namespace adm {
   }
 
   AudioPackFormatId IdReassigner::IdIssuer::issueAudioPackFormatId(
-      TypeDescriptor typeDescriptor) {
+      const TypeDescriptor& typeDescriptor) {
     auto it = nextAudioPackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;
@@ -269,7 +269,7 @@ namespace adm {
   }
 
   AudioChannelFormatId IdReassigner::IdIssuer::issueAudioChannelFormatId(
-      TypeDescriptor typeDescriptor) {
+      const TypeDescriptor& typeDescriptor) {
     auto it = nextAudioChannelStreamTrackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;
@@ -279,7 +279,7 @@ namespace adm {
     return id;
   }
   uint16_t IdReassigner::IdIssuer::issueAudioChannelStreamTrackFormatIdValue(
-      TypeDescriptor typeDescriptor) {
+      const TypeDescriptor& typeDescriptor) {
     auto it = nextAudioChannelStreamTrackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -185,6 +185,8 @@ namespace adm {
           if (idValue == 0)
             idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
                 typeDescriptor);
+          if (audioTrackFormatIdCounter > 0xFFu)
+            throw std::runtime_error("No AudioTrackFormatIdCounter available");
           audioTrackFormatId.set(typeDescriptor);
           audioTrackFormatId.set(AudioTrackFormatIdValue{idValue});
           audioTrackFormatId.set(audioTrackFormatIdCounter);

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -1,7 +1,20 @@
 #include "adm/utilities/id_assignment.hpp"
 
 namespace adm {
-
+  /**
+   * @brief Reassigns ID's to all elements within a Document.
+   *
+   * Works by clearing existing ID's and then reassigning unique
+   * ID's to each element. For AudioTrackFormat, AudioStreamFormat
+   * and AudioChannelFormat, new ID's are only assigned if they
+   * form a functional part of the ADM though releationships to
+   * other elements. Those that don't do not get assigned new ID's
+   * after being cleared and are therefore marked as elements to
+   * be ignored.
+   * 
+   * @param document Document that will have element ID's 
+   * reassigned.
+   */
   class IdReassigner {
    public:
     IdReassigner(std::shared_ptr<Document> document);
@@ -17,6 +30,16 @@ namespace adm {
     void reassignAudioBlockFormatIds(
         std::shared_ptr<AudioChannelFormat> audioChannelFormat);
 
+    /**
+     * @brief Class responsible for issuing new ID's for elements.
+     *
+     * Starts at initial ID values and counts up as ID's are 
+     * handed out. Ensures ID's are sequential and unique.
+     * A single ID value can also be issued for a related group
+     * of AudioTrackFormat, AudioStreamFormat and 
+     * AudioChannelFormat elements to make the ADM XML easier to
+     * follow.
+     */
     class IdIssuer {
      public:
       IdIssuer();

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -5,10 +5,9 @@ namespace adm {
   class IdReassigner {
    public:
     IdReassigner(std::shared_ptr<Document> document);
-
-   private:
     void reassignAllIds();
 
+   private:
     void reassignAudioProgrammeIds();
     void reassignAudioContentIds();
     void reassignAudioObjectIds();
@@ -59,13 +58,12 @@ namespace adm {
   }
 
   void reassignIds(std::shared_ptr<Document> document) {
-    IdReassigner{document};
+    IdReassigner idReassigner(document);
+    idReassigner.reassignAllIds();
   }
 
   IdReassigner::IdReassigner(std::shared_ptr<Document> document)
-      : document{document} {
-    reassignAllIds();
-  }
+      : document{document} {}
 
   void IdReassigner::reassignAllIds() {
     reassignAudioProgrammeIds();

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -12,9 +12,8 @@ namespace adm {
   void reassignAudioBlockFormatIds(
       std::shared_ptr<AudioChannelFormat> channelFormat);
 
-  uint16_t getAvailableIdValue(
-      std::shared_ptr<adm::Document> doc, const adm::TypeDescriptor& td) {
-
+  uint16_t getAvailableIdValue(std::shared_ptr<adm::Document> doc,
+                               const adm::TypeDescriptor& td) {
     // We want to find a matching set of available ATF, ASF and ACF ID's
     AudioChannelFormatId acfId;
     AudioStreamFormatId asfId;
@@ -126,7 +125,7 @@ namespace adm {
         // If no ACF, don't process this tree - it's redundant
         // This is similar to previous logic, since the TD component of ID's
         // was pulled from the ACF, so no ACF left an undef TD type in
-        // ASF ID and all associated ATF ID's 
+        // ASF ID and all associated ATF ID's
         continue;
       }
       auto td = audioChannelFormat->template get<TypeDescriptor>();
@@ -166,7 +165,6 @@ namespace adm {
           audioTrackFormatIdCounter++;
         }
       }
-
     }
   }
 
@@ -185,8 +183,7 @@ namespace adm {
         auto audioChannelFormatId =
             audioChannelFormat->template get<AudioChannelFormatId>();
         if (!isCommonDefinitionsId(audioChannelFormatId)) {
-          auto channelFormatType =
-              audioChannelFormat->get<TypeDescriptor>();
+          auto channelFormatType = audioChannelFormat->get<TypeDescriptor>();
           auto doc = audioChannelFormat->getParent().lock();
           if (doc) {
             auto idValue = getAvailableIdValue(doc, channelFormatType);

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -234,26 +234,35 @@ namespace adm {
 
   IdReassigner::IdIssuer::IdIssuer() {}
   AudioProgrammeId IdReassigner::IdIssuer::issueAudioProgrammeId() {
+    if (nextAudioProgrammeIdValue > 0xFFFFu)
+      throw std::runtime_error("No AudioProgrammeId available");
     AudioProgrammeId id;
-    id.set(nextAudioProgrammeIdValue++);
+    id.set(AudioProgrammeIdValue(nextAudioProgrammeIdValue++));
     return id;
   }
 
   AudioContentId IdReassigner::IdIssuer::issueAudioContentId() {
+    if (nextAudioContentIdValue > 0xFFFFu)
+      throw std::runtime_error("No AudioContentId available");
     AudioContentId id;
-    id.set(nextAudioContentIdValue++);
+    id.set(AudioContentIdValue(nextAudioContentIdValue++));
     return id;
   }
 
   AudioObjectId IdReassigner::IdIssuer::issueAudioObjectId() {
+    if (nextAudioObjectIdValue > 0xFFFFu)
+      throw std::runtime_error("No AudioObjectId available");
     AudioObjectId id;
-    id.set(nextAudioObjectIdValue++);
+    id.set(AudioObjectIdValue(nextAudioObjectIdValue++));
     return id;
   }
 
   AudioTrackUidId IdReassigner::IdIssuer::issueAudioTrackUidId() {
+    if (nextAudioTrackUidIdValue > 0xFFFFFFFFu)
+      throw std::runtime_error("No AudioTrackUidId available");
     AudioTrackUidId id;
-    id.set(nextAudioTrackUidIdValue++);
+    id.set(AudioTrackUidIdValue(
+        static_cast<uint32_t>(nextAudioTrackUidIdValue++)));
     return id;
   }
 
@@ -262,9 +271,11 @@ namespace adm {
     auto it = nextAudioPackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;
+    if (it->second > 0xFFFFu)
+      throw std::runtime_error("No AudioPackFormatId available");
     AudioPackFormatId id;
     id.set(typeDescriptor);
-    id.set(it->second++);
+    id.set(AudioPackFormatIdValue(it->second++));
     return id;
   }
 
@@ -273,6 +284,8 @@ namespace adm {
     auto it = nextAudioChannelStreamTrackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;
+    if (it->second > 0xFFFFu)
+      throw std::runtime_error("No AudioChannelFormatId available");
     AudioChannelFormatId id;
     id.set(typeDescriptor);
     id.set(AudioChannelFormatIdValue(it->second++));
@@ -283,7 +296,11 @@ namespace adm {
     auto it = nextAudioChannelStreamTrackFormatIdValue
                   .insert(std::make_pair(typeDescriptor, 0x1001))
                   .first;
-    return it->second++;
+    if (it->second > 0xFFFFu)
+      throw std::runtime_error(
+          "No common AudioChannelFormat, AudioStreamFormat, AudioTrackFormat "
+          "ID value available");
+    return static_cast<uint16_t>(it->second++);
   }
 
 }  // namespace adm

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -2,6 +2,50 @@
 
 namespace adm {
 
+  class IdReassigner {
+   public:
+    IdReassigner(std::shared_ptr<Document> document);
+
+   private:
+    void reassignAllIds();
+
+    void reassignAudioProgrammeIds();
+    void reassignAudioContentIds();
+    void reassignAudioObjectIds();
+    void reassignAudioPackFormatIds();
+    void reassignAudioStreamFormatIds();
+    void reassignAudioTrackUidIds();
+    void reassignAudioBlockFormatIds(
+        std::shared_ptr<AudioChannelFormat> audioChannelFormat);
+
+    class IdIssuer {
+     public:
+      IdIssuer();
+      AudioProgrammeId issueAudioProgrammeId();
+      AudioContentId issueAudioContentId();
+      AudioObjectId issueAudioObjectId();
+      AudioTrackUidId issueAudioTrackUidId();
+      AudioPackFormatId issueAudioPackFormatId(
+          const TypeDescriptor& typeDescriptor);
+      AudioChannelFormatId issueAudioChannelFormatId(
+          const TypeDescriptor& typeDescriptor);
+      uint16_t issueAudioChannelStreamTrackFormatIdValue(
+          const TypeDescriptor& typeDescriptor);
+
+     private:
+      uint32_t nextAudioProgrammeIdValue{0x1001u};
+      uint32_t nextAudioContentIdValue{0x1001u};
+      uint32_t nextAudioObjectIdValue{0x1001u};
+      uint64_t nextAudioTrackUidIdValue{0x00000001u};
+      std::map<TypeDescriptor, uint32_t> nextAudioPackFormatIdValue;
+      std::map<TypeDescriptor, uint32_t>
+          nextAudioChannelStreamTrackFormatIdValue;
+
+    } idIssuer;
+
+    std::shared_ptr<Document> document;
+  };
+
   template <typename It>
   void undefineIds(It begin, It end) {
     for (auto it = begin; it != end; ++it) {

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -104,7 +104,7 @@ namespace adm {
         continue;
       }
       auto typeDescriptor = audioChannelFormat->get<TypeDescriptor>();
-      uint16_t idValue = 0; // don't issue unless needed
+      uint16_t idValue = 0;  // don't issue unless needed
 
       // AudioStreamFormat
       auto audioStreamFormatId = audioStreamFormat->get<AudioStreamFormatId>();
@@ -141,8 +141,8 @@ namespace adm {
         auto audioTrackFormatId = audioTrackFormat->get<AudioTrackFormatId>();
         if (!isCommonDefinitionsId(audioTrackFormatId)) {
           if (idValue == 0)
-          idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
-              typeDescriptor);
+            idValue = idIssuer.issueAudioChannelStreamTrackFormatIdValue(
+                typeDescriptor);
           audioTrackFormatId.set(typeDescriptor);
           audioTrackFormatId.set(AudioTrackFormatIdValue{idValue});
           audioTrackFormatId.set(audioTrackFormatIdCounter);

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -277,9 +277,7 @@ namespace adm {
 
   AudioPackFormatId IdReassigner::IdIssuer::issueAudioPackFormatId(
       const TypeDescriptor& typeDescriptor) {
-    auto it = nextAudioPackFormatIdValue
-                  .insert(std::make_pair(typeDescriptor, 0x1001))
-                  .first;
+    auto it = nextAudioPackFormatIdValue.emplace(typeDescriptor, 0x1001).first;
     if (it->second > 0xFFFFu)
       throw std::runtime_error("No AudioPackFormatId available");
     AudioPackFormatId id;
@@ -290,9 +288,9 @@ namespace adm {
 
   AudioChannelFormatId IdReassigner::IdIssuer::issueAudioChannelFormatId(
       const TypeDescriptor& typeDescriptor) {
-    auto it = nextAudioChannelStreamTrackFormatIdValue
-                  .insert(std::make_pair(typeDescriptor, 0x1001))
-                  .first;
+    auto it =
+        nextAudioChannelStreamTrackFormatIdValue.emplace(typeDescriptor, 0x1001)
+            .first;
     if (it->second > 0xFFFFu)
       throw std::runtime_error("No AudioChannelFormatId available");
     AudioChannelFormatId id;
@@ -302,9 +300,9 @@ namespace adm {
   }
   uint16_t IdReassigner::IdIssuer::issueAudioChannelStreamTrackFormatIdValue(
       const TypeDescriptor& typeDescriptor) {
-    auto it = nextAudioChannelStreamTrackFormatIdValue
-                  .insert(std::make_pair(typeDescriptor, 0x1001))
-                  .first;
+    auto it =
+        nextAudioChannelStreamTrackFormatIdValue.emplace(typeDescriptor, 0x1001)
+            .first;
     if (it->second > 0xFFFFu)
       throw std::runtime_error(
           "No common AudioChannelFormat, AudioStreamFormat, AudioTrackFormat "

--- a/src/utilities/id_assignment.cpp
+++ b/src/utilities/id_assignment.cpp
@@ -135,6 +135,7 @@ namespace adm {
       auto audioStreamFormatId =
           audioStreamFormat->template get<AudioStreamFormatId>();
       if (!isCommonDefinitionsId(audioStreamFormatId)) {
+        audioStreamFormatId.set(td);
         audioStreamFormatId.set(AudioStreamFormatIdValue{idValue});
         audioStreamFormat->set(audioStreamFormatId);
       }
@@ -143,6 +144,7 @@ namespace adm {
       auto audioChannelFormatId =
           audioChannelFormat->template get<AudioChannelFormatId>();
       if (!isCommonDefinitionsId(audioChannelFormatId)) {
+        audioChannelFormatId.set(td);
         audioChannelFormatId.set(AudioChannelFormatIdValue{idValue});
         audioChannelFormat->set(audioChannelFormatId);
         reassignAudioBlockFormatIds(audioChannelFormat);
@@ -159,6 +161,7 @@ namespace adm {
         auto audioTrackFormatId =
             audioTrackFormat->template get<AudioTrackFormatId>();
         if (!isCommonDefinitionsId(audioTrackFormatId)) {
+          audioTrackFormatId.set(td);
           audioTrackFormatId.set(AudioTrackFormatIdValue{idValue});
           audioTrackFormatId.set(audioTrackFormatIdCounter);
           audioTrackFormat->set(audioTrackFormatId);

--- a/src/utilities/object_creation.cpp
+++ b/src/utilities/object_creation.cpp
@@ -39,6 +39,34 @@ namespace adm {
     return holder;
   }
 
+  SimpleObjectHolder createSimpleObjectShortStructure(const std::string& name) {
+    // create without ASF and ATF refs
+    SimpleObjectHolder holder;
+    holder.audioObject = AudioObject::create(AudioObjectName(name));
+
+    holder.audioPackFormat = AudioPackFormat::create(AudioPackFormatName(name),
+                                                     TypeDefinition::OBJECTS);
+    holder.audioChannelFormat = AudioChannelFormat::create(
+        AudioChannelFormatName(name), TypeDefinition::OBJECTS);
+    holder.audioTrackUid = AudioTrackUid::create();
+
+    // reference
+    holder.audioObject->addReference(holder.audioPackFormat);
+    holder.audioPackFormat->addReference(holder.audioChannelFormat);
+    holder.audioObject->addReference(holder.audioTrackUid);
+    holder.audioTrackUid->setReference(holder.audioChannelFormat);
+    holder.audioTrackUid->setReference(holder.audioPackFormat);
+
+    return holder;
+  }
+
+  SimpleObjectHolder addSimpleObjectShortStructureTo(
+      std::shared_ptr<Document> document, const std::string& name) {
+    auto holder = createSimpleObjectShortStructure(name);
+    document->add(holder.audioObject);
+    return holder;
+  }
+
   SimpleCommonDefinitionsObjectHolder addSimpleCommonDefinitionsObjectTo(
       std::shared_ptr<Document> document, const std::string& name,
       const std::string& speakerLayout) {

--- a/tests/adm_document_tests.cpp
+++ b/tests/adm_document_tests.cpp
@@ -282,7 +282,7 @@ TEST_CASE("copy_document_all_adm_elements") {
 
   // add to document1 and reassign ids
   admDocument->add(myProgramme);
-  // reassignIds(admDocument);
+  reassignIds(admDocument);
 
   REQUIRE(admDocument->getElements<AudioProgramme>().size() == 1);
   REQUIRE(admDocument->getElements<AudioContent>().size() == 1);

--- a/tests/helper/file_comparator.hpp
+++ b/tests/helper/file_comparator.hpp
@@ -12,12 +12,16 @@ class FileComparator : public Catch::MatcherBase<std::string> {
 
   virtual bool match(const std::string& received) const override {
     bool check_successful = false;
-    std::ifstream acceptedFile(filename_ + ".accepted." + extension_);
+    std::string acceptedFilePath = filename_ + ".accepted." + extension_;
+    std::ifstream acceptedFile(acceptedFilePath);
     if (acceptedFile.is_open()) {
       std::string acceptedStr((std::istreambuf_iterator<char>(acceptedFile)),
                               std::istreambuf_iterator<char>());
       check_successful = (acceptedStr == received);
       acceptedFile.close();
+    } else {
+      std::string msg("FileComparator - Unable to open test data: ");
+      throw std::runtime_error(msg + acceptedFilePath);
     }
     // write to file if not successful
     if (!check_successful) {

--- a/tests/test_data/write_mixed_objects_and_structures.accepted.xml
+++ b/tests/test_data/write_mixed_objects_and_structures.accepted.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ebuCoreMain xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="urn:ebu:metadata-schema:ebuCore_2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schema="EBU_CORE_20140201.xsd" xml:lang="en">
+	<coreMetadata>
+		<format>
+			<audioFormatExtended>
+				<audioObject audioObjectID="AO_1001" audioObjectName="Simple Object 1">
+					<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_00000001</audioTrackUIDRef>
+				</audioObject>
+				<audioObject audioObjectID="AO_1002" audioObjectName="Simple Object 2 (short structured)">
+					<audioPackFormatIDRef>AP_00031002</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_00000002</audioTrackUIDRef>
+				</audioObject>
+				<audioObject audioObjectID="AO_1003" audioObjectName="5.1 Object 3">
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_00000003</audioTrackUIDRef>
+					<audioTrackUIDRef>ATU_00000004</audioTrackUIDRef>
+					<audioTrackUIDRef>ATU_00000005</audioTrackUIDRef>
+					<audioTrackUIDRef>ATU_00000006</audioTrackUIDRef>
+					<audioTrackUIDRef>ATU_00000007</audioTrackUIDRef>
+					<audioTrackUIDRef>ATU_00000008</audioTrackUIDRef>
+				</audioObject>
+				<audioObject audioObjectID="AO_1004" audioObjectName="Simple Object 4">
+					<audioPackFormatIDRef>AP_00031003</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_00000009</audioTrackUIDRef>
+				</audioObject>
+				<audioObject audioObjectID="AO_1005" audioObjectName="Simple Object 5 (short structured)">
+					<audioPackFormatIDRef>AP_00031004</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_0000000a</audioTrackUIDRef>
+				</audioObject>
+				<audioPackFormat audioPackFormatID="AP_00031001" audioPackFormatName="Simple Object 1" typeLabel="0003" typeDefinition="Objects">
+					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
+				</audioPackFormat>
+				<audioPackFormat audioPackFormatID="AP_00031002" audioPackFormatName="Simple Object 2 (short structured)" typeLabel="0003" typeDefinition="Objects">
+					<audioChannelFormatIDRef>AC_00031003</audioChannelFormatIDRef>
+				</audioPackFormat>
+				<audioPackFormat audioPackFormatID="AP_00031003" audioPackFormatName="Simple Object 4" typeLabel="0003" typeDefinition="Objects">
+					<audioChannelFormatIDRef>AC_00031002</audioChannelFormatIDRef>
+				</audioPackFormat>
+				<audioPackFormat audioPackFormatID="AP_00031004" audioPackFormatName="Simple Object 5 (short structured)" typeLabel="0003" typeDefinition="Objects">
+					<audioChannelFormatIDRef>AC_00031004</audioChannelFormatIDRef>
+				</audioPackFormat>
+				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="Simple Object 1" typeLabel="0003" typeDefinition="Objects"/>
+				<audioChannelFormat audioChannelFormatID="AC_00031003" audioChannelFormatName="Simple Object 2 (short structured)" typeLabel="0003" typeDefinition="Objects"/>
+				<audioChannelFormat audioChannelFormatID="AC_00031002" audioChannelFormatName="Simple Object 4" typeLabel="0003" typeDefinition="Objects"/>
+				<audioChannelFormat audioChannelFormatID="AC_00031004" audioChannelFormatName="Simple Object 5 (short structured)" typeLabel="0003" typeDefinition="Objects"/>
+				<audioStreamFormat audioStreamFormatID="AS_00031001" audioStreamFormatName="Simple Object 1" formatLabel="0001" formatDefinition="PCM">
+					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
+					<audioTrackFormatIDRef>AT_00031001_01</audioTrackFormatIDRef>
+				</audioStreamFormat>
+				<audioStreamFormat audioStreamFormatID="AS_00031002" audioStreamFormatName="Simple Object 4" formatLabel="0001" formatDefinition="PCM">
+					<audioChannelFormatIDRef>AC_00031002</audioChannelFormatIDRef>
+					<audioTrackFormatIDRef>AT_00031002_01</audioTrackFormatIDRef>
+				</audioStreamFormat>
+				<audioTrackFormat audioTrackFormatID="AT_00031001_01" audioTrackFormatName="Simple Object 1" formatLabel="0001" formatDefinition="PCM">
+					<audioStreamFormatIDRef>AS_00031001</audioStreamFormatIDRef>
+				</audioTrackFormat>
+				<audioTrackFormat audioTrackFormatID="AT_00031002_01" audioTrackFormatName="Simple Object 4" formatLabel="0001" formatDefinition="PCM">
+					<audioStreamFormatIDRef>AS_00031002</audioStreamFormatIDRef>
+				</audioTrackFormat>
+				<audioTrackUID UID="ATU_00000001">
+					<audioTrackFormatIDRef>AT_00031001_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000002">
+					<audioChannelFormatIDRef>AC_00031003</audioChannelFormatIDRef>
+					<audioPackFormatIDRef>AP_00031002</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000003">
+					<audioTrackFormatIDRef>AT_00010001_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000004">
+					<audioTrackFormatIDRef>AT_00010002_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000005">
+					<audioTrackFormatIDRef>AT_00010003_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000006">
+					<audioTrackFormatIDRef>AT_00010004_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000007">
+					<audioTrackFormatIDRef>AT_00010005_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000008">
+					<audioTrackFormatIDRef>AT_00010006_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00010003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_00000009">
+					<audioTrackFormatIDRef>AT_00031002_01</audioTrackFormatIDRef>
+					<audioPackFormatIDRef>AP_00031003</audioPackFormatIDRef>
+				</audioTrackUID>
+				<audioTrackUID UID="ATU_0000000a">
+					<audioChannelFormatIDRef>AC_00031004</audioChannelFormatIDRef>
+					<audioPackFormatIDRef>AP_00031004</audioPackFormatIDRef>
+				</audioTrackUID>
+			</audioFormatExtended>
+		</format>
+	</coreMetadata>
+</ebuCoreMain>
+

--- a/tests/test_data/write_simple_object_short_structure.accepted.xml
+++ b/tests/test_data/write_simple_object_short_structure.accepted.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ebuCoreMain xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="urn:ebu:metadata-schema:ebuCore_2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schema="EBU_CORE_20140201.xsd" xml:lang="en">
+	<coreMetadata>
+		<format>
+			<audioFormatExtended>
+				<audioObject audioObjectID="AO_1001" audioObjectName="My Simple Short Structured Object">
+					<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
+					<audioTrackUIDRef>ATU_00000001</audioTrackUIDRef>
+				</audioObject>
+				<audioPackFormat audioPackFormatID="AP_00031001" audioPackFormatName="My Simple Short Structured Object" typeLabel="0003" typeDefinition="Objects">
+					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
+				</audioPackFormat>
+				<audioChannelFormat audioChannelFormatID="AC_00031001" audioChannelFormatName="My Simple Short Structured Object" typeLabel="0003" typeDefinition="Objects"/>
+				<audioTrackUID UID="ATU_00000001">
+					<audioChannelFormatIDRef>AC_00031001</audioChannelFormatIDRef>
+					<audioPackFormatIDRef>AP_00031001</audioPackFormatIDRef>
+				</audioTrackUID>
+			</audioFormatExtended>
+		</format>
+	</coreMetadata>
+</ebuCoreMain>
+

--- a/tests/xml_writer_objects_creation_tests.cpp
+++ b/tests/xml_writer_objects_creation_tests.cpp
@@ -21,6 +21,19 @@ TEST_CASE("write_simple_object") {
   CHECK_THAT(xml.str(), EqualsXmlFile("write_simple_object"));
 }
 
+TEST_CASE("write_simple_object_short_structure") {
+  using namespace adm;
+
+  auto document = Document::create();
+  addSimpleObjectShortStructureTo(document, "My Simple Short Structured Object");
+  reassignIds(document);
+
+  std::stringstream xml;
+  writeXml(xml, document);
+
+  CHECK_THAT(xml.str(), EqualsXmlFile("write_simple_object_short_structure"));
+}
+
 TEST_CASE("write_simple_common_definitions_object") {
   using namespace adm;
 
@@ -41,4 +54,24 @@ TEST_CASE("write_simple_common_definitions_object") {
 
   CHECK_THAT(xml.str(),
              EqualsXmlFile("write_simple_common_definitions_object"));
+}
+
+TEST_CASE("write_mixed_objects_and_structures") {
+  using namespace adm;
+
+  auto document = Document::create();
+  addCommonDefinitionsTo(document);
+  addSimpleObjectTo(document, "Simple Object 1");
+  addSimpleObjectShortStructureTo(document,
+                                  "Simple Object 2 (short structured)");
+  addSimpleCommonDefinitionsObjectTo(document, "5.1 Object 3", "0+5+0");
+  addSimpleObjectTo(document, "Simple Object 4");
+  addSimpleObjectShortStructureTo(document,
+                                  "Simple Object 5 (short structured)");
+  reassignIds(document);
+
+  std::stringstream xml;
+  writeXml(xml, document);
+
+  CHECK_THAT(xml.str(), EqualsXmlFile("write_mixed_objects_and_structures"));
 }

--- a/tests/xml_writer_objects_creation_tests.cpp
+++ b/tests/xml_writer_objects_creation_tests.cpp
@@ -25,7 +25,8 @@ TEST_CASE("write_simple_object_short_structure") {
   using namespace adm;
 
   auto document = Document::create();
-  addSimpleObjectShortStructureTo(document, "My Simple Short Structured Object");
+  addSimpleObjectShortStructureTo(document,
+                                  "My Simple Short Structured Object");
   reassignIds(document);
 
   std::stringstream xml;


### PR DESCRIPTION
Closes #181 

See issue ticket for more details

The approach has been to process ACFs stemming from ATUIDs in the `reassignAudioTrackUidIds`. If an ACF is found, apply an available ACF ID.

However, other ACF IDs (and ATF and ASF IDs) were applied in the `reassignAudioStreamFormatIds` function which just blindly applies IDs sequentially, because previously this was fine and logical to do - it was the only function assigning IDs to ACF elements. Therefore this function could now inadvertently assign the same ID to more than one ACF because there were no checks to see if the ID was available.

~~Therefore the new `getAvailableIdValue` function was written will find an available ID value to use with ACF, ATF and ASF groups. It ensures the ID value is available for all 3 element types so that they can share the same value and make the ADM XML more readable and easy to follow.~~

~~The disadvantage of this approach is that available ID lookup has exponential complexity based on ACF count. However, given that `reassignIds` is not expected to be called repeatedly, and that even a "large" ADM document only has maybe 128 ACFs requiring ID assignment, this is probably fine.~~

Update:
The whole reassignIds logic has been wrapped in a class, with an IdIssuer class used to track IDs and ensure only unique ID's are issued to elements. This avoids the need for lookups and reduces to linear complexity. Note that a common ID value is used for groups of ACF, ATF and ASF elements so that the ADM XML is more readable and easy to follow.