### PR TITLE
NamedType: add defaults and make sure state stays valid

### DIFF
--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -39,7 +39,6 @@ namespace adm {
       explicit NamedType(T&& value) : value_(std::move(value)) {
         Validator::validate(get());
       }
-      T& get() { return value_; }
       T const& get() const { return value_; }
 
       bool operator==(const NamedType<T, Tag, Validator>& other) const {
@@ -117,9 +116,7 @@ namespace adm {
         return tmp;
       }
 
-      T* operator->() { return &value_; }
       T const* operator->() const { return &value_; }
-      T& operator*() { return value_; }
       T const& operator*() const { return value_; }
 
      private:

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -44,6 +44,18 @@ namespace adm {
       explicit NamedType(T&& value) : value_(std::move(value)) {
         Validator::validate(get());
       }
+
+      NamedType& operator=(const T& value) {
+        Validator::validate(value);
+        value_ = value;
+        return *this;
+      }
+      NamedType& operator=(T&& value) {
+        Validator::validate(value);
+        value_ = std::move(value);
+        return *this;
+      }
+
       T const& get() const { return value_; }
 
       bool operator==(const NamedType<T, Tag, Validator>& other) const {

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -56,7 +56,13 @@ namespace adm {
         return *this;
       }
 
-      T const& get() const { return value_; }
+      T const& get() const& { return value_; }
+
+      T get() && {
+        T tmp = std::move(value_);
+        *this = getNamedTypeDefault<NamedType>();
+        return tmp;
+      }
 
       bool operator==(const NamedType<T, Tag, Validator>& other) const {
         return this->get() == other.get();

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -112,7 +112,10 @@ namespace adm {
       }
 
       NamedType<T, Tag, Validator>& operator++() {
-        ++value_;
+        T tmp = value_;
+        tmp++;
+        Validator::validate(tmp);
+        value_ = std::move(tmp);
         return *this;
       }
 
@@ -123,7 +126,10 @@ namespace adm {
       }
 
       NamedType<T, Tag, Validator>& operator--() {
-        --value_;
+        T tmp = value_;
+        tmp--;
+        Validator::validate(tmp);
+        value_ = std::move(tmp);
         return *this;
       }
 

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -9,6 +9,15 @@ namespace adm {
   /// @brief Implementation details
   namespace detail {
 
+    /// Get the default value for some NamedType; specialise this to add custom
+    /// defaults. Note that this is mainly used to make NamedType values
+    /// default-constructable when the validator doesn't accept the default
+    /// value of the underlying type.
+    template <typename NT>
+    NT getNamedTypeDefault() {
+      return NT{typename NT::value_type{}};
+    }
+
     /**
      * @brief Named type class
      *
@@ -22,7 +31,8 @@ namespace adm {
       typedef T value_type;
       typedef Tag tag;
 
-      NamedType() : value_() { Validator::validate(get()); }
+      NamedType() : NamedType(getNamedTypeDefault<NamedType>()) {}
+
       explicit NamedType(T const& value) : value_(value) {
         Validator::validate(get());
       }

--- a/include/adm/detail/named_type.hpp
+++ b/include/adm/detail/named_type.hpp
@@ -33,6 +33,11 @@ namespace adm {
 
       NamedType() : NamedType(getNamedTypeDefault<NamedType>()) {}
 
+      NamedType(const NamedType&) = default;
+      NamedType(NamedType&&) = default;
+      NamedType& operator=(const NamedType&) = default;
+      NamedType& operator=(NamedType&&) = default;
+
       explicit NamedType(T const& value) : value_(value) {
         Validator::validate(get());
       }

--- a/include/adm/elements/common_parameters.hpp
+++ b/include/adm/elements/common_parameters.hpp
@@ -13,7 +13,7 @@
 namespace adm {
   namespace detail {
     template <>
-    inline Importance getDefault<Importance>() {
+    inline Importance getNamedTypeDefault<Importance>() {
       return Importance{10};
     }
 
@@ -23,22 +23,22 @@ namespace adm {
     }
 
     template <>
-    inline Rtime getDefault<Rtime>() {
+    inline Rtime getNamedTypeDefault<Rtime>() {
       return Rtime{std::chrono::nanoseconds{0}};
     }
 
     template <>
-    inline HeadLocked getDefault<HeadLocked>() {
+    inline HeadLocked getNamedTypeDefault<HeadLocked>() {
       return HeadLocked{false};
     }
 
     template <>
-    inline ScreenRef getDefault<ScreenRef>() {
+    inline ScreenRef getNamedTypeDefault<ScreenRef>() {
       return ScreenRef{false};
     }
 
     template <>
-    inline Normalization getDefault<Normalization>() {
+    inline Normalization getNamedTypeDefault<Normalization>() {
       return Normalization{"SN3D"};
     }
 

--- a/include/adm/elements/frequency.hpp
+++ b/include/adm/elements/frequency.hpp
@@ -35,6 +35,13 @@ namespace adm {
    */
   using LowPass = detail::NamedType<float, LowPassTag, detail::MinValidator<0>>;
 
+  namespace detail {
+    template <>
+    inline FrequencyType getNamedTypeDefault<FrequencyType>() {
+      return FrequencyType{"lowPass"};
+    }
+  }  // namespace detail
+
   /// @brief Tag for Frequency class
   struct FrequencyTag {};
   /**

--- a/include/adm/elements/gain_interaction_range.hpp
+++ b/include/adm/elements/gain_interaction_range.hpp
@@ -35,6 +35,24 @@ namespace adm {
       detail::NamedType<std::string, GainInteractionBoundValueTag,
                         detail::BoundValueValidator>;
 
+  namespace detail {
+    template <>
+    inline GainInteractionMin getNamedTypeDefault<GainInteractionMin>() {
+      return GainInteractionMin{Gain::fromLinear(1.0)};
+    }
+
+    template <>
+    inline GainInteractionMax getNamedTypeDefault<GainInteractionMax>() {
+      return GainInteractionMax{Gain::fromLinear(1.0)};
+    }
+
+    template <>
+    inline GainInteractionBoundValue
+    getNamedTypeDefault<GainInteractionBoundValue>() {
+      return GainInteractionBoundValue{"min"};
+    }
+  }  // namespace detail
+
   /// @brief Tag for GainInteractionRange class
   struct GainInteractionRangeTag {};
   /**

--- a/include/adm/elements/position_interaction_range.hpp
+++ b/include/adm/elements/position_interaction_range.hpp
@@ -91,6 +91,21 @@ namespace adm {
   using CoordinateInteractionValue =
       detail::NamedType<std::string, CoordinateInteractionValueTag,
                         detail::CoordinateValueValidator>;
+
+  namespace detail {
+    template <>
+    inline PositionInteractionBoundValue
+    getNamedTypeDefault<PositionInteractionBoundValue>() {
+      return PositionInteractionBoundValue{"min"};
+    }
+
+    template <>
+    inline CoordinateInteractionValue
+    getNamedTypeDefault<CoordinateInteractionValue>() {
+      return CoordinateInteractionValue{"azimuth"};
+    }
+  }  // namespace detail
+
   /// @brief Tag for PositionInteractionRange class
   struct PositionInteractionRangeTag {};
   /**

--- a/include/adm/elements/position_types.hpp
+++ b/include/adm/elements/position_types.hpp
@@ -174,4 +174,18 @@ namespace adm {
   using CartesianCoordinateValue =
       detail::NamedType<std::string, CartesianCoordinateValueTag,
                         detail::CartesianCoordinateValueValidator>;
+
+  namespace detail {
+    template <>
+    inline SphericalCoordinateValue
+    getNamedTypeDefault<SphericalCoordinateValue>() {
+      return SphericalCoordinateValue{"azimuth"};
+    }
+
+    template <>
+    inline CartesianCoordinateValue
+    getNamedTypeDefault<CartesianCoordinateValue>() {
+      return CartesianCoordinateValue{"X"};
+    }
+  }  // namespace detail
 }  // namespace adm

--- a/include/adm/elements/screen_edge_lock.hpp
+++ b/include/adm/elements/screen_edge_lock.hpp
@@ -36,6 +36,23 @@ namespace adm {
   using VerticalEdge = detail::NamedType<std::string, VerticalEdgeTag,
                                          detail::VerticalEdgeValidator>;
 
+  namespace detail {
+    template <>
+    inline ScreenEdge getNamedTypeDefault<ScreenEdge>() {
+      return ScreenEdge{"left"};
+    }
+
+    template <>
+    inline HorizontalEdge getNamedTypeDefault<HorizontalEdge>() {
+      return HorizontalEdge{"left"};
+    }
+
+    template <>
+    inline VerticalEdge getNamedTypeDefault<VerticalEdge>() {
+      return VerticalEdge{"top"};
+    }
+  }  // namespace detail
+
   /// @brief Tag for ScreenEdgeLock class
   struct ScreenEdgeLockTag {};
   /**

--- a/include/adm/elements/speaker_position.hpp
+++ b/include/adm/elements/speaker_position.hpp
@@ -21,6 +21,13 @@ namespace adm {
   using BoundValue = detail::NamedType<std::string, BoundValueTag,
                                        detail::BoundValueValidator>;
 
+  namespace detail {
+    template <>
+    inline BoundValue getNamedTypeDefault<BoundValue>() {
+      return BoundValue{"min"};
+    }
+  }  // namespace detail
+
   /// @brief Tag for CartesianSpeakerPosition class
   struct CartesianSpeakerPositionTag {};
   /**

--- a/tests/named_type_tests.cpp
+++ b/tests/named_type_tests.cpp
@@ -52,6 +52,16 @@ TEST_CASE("NamedType_range_check") {
   NamedIntegerRange goodValue(5);
   REQUIRE_THROWS_AS(NamedIntegerRange(12), OutOfRangeError);
   REQUIRE_THROWS_AS(NamedIntegerRange(-1), OutOfRangeError);
+
+  NamedIntegerRange lower_limit(0);
+  REQUIRE_THROWS_AS(lower_limit--, OutOfRangeError);
+  REQUIRE_THROWS_AS(--lower_limit, OutOfRangeError);
+  REQUIRE(lower_limit == 0);
+
+  NamedIntegerRange upper_limit(10);
+  REQUIRE_THROWS_AS(upper_limit++, OutOfRangeError);
+  REQUIRE_THROWS_AS(++upper_limit, OutOfRangeError);
+  REQUIRE(upper_limit == 10);
 }
 
 TEST_CASE("screen_edge_validator") {

--- a/tests/named_type_tests.cpp
+++ b/tests/named_type_tests.cpp
@@ -64,6 +64,41 @@ TEST_CASE("NamedType_range_check") {
   REQUIRE(upper_limit == 10);
 }
 
+class MoveOnly {
+ public:
+  MoveOnly() : value(0) {}
+  MoveOnly(int value) : value(value) {}
+
+  MoveOnly(MoveOnly const &) = delete;
+  MoveOnly &operator=(MoveOnly const &) = delete;
+
+  MoveOnly(MoveOnly &&) = default;
+  MoveOnly &operator=(MoveOnly &&) = default;
+
+  int get() const { return value; }
+
+ private:
+  int value;
+};
+
+struct MoveOnlyTag {};
+using NamedMoveOnly = adm::detail::NamedType<MoveOnly, MoveOnlyTag>;
+
+TEST_CASE("NamedType_move") {
+  NamedMoveOnly value{MoveOnly{1}};
+
+  MoveOnly moved = std::move(value).get();
+  REQUIRE(moved.get() == 1);
+  REQUIRE(value.get().get() == 0);
+
+  MoveOnly moved_from_temporary = std::move(NamedMoveOnly{MoveOnly{2}}).get();
+  REQUIRE(moved_from_temporary.get() == 2);
+
+  value = MoveOnly{3};
+  NamedMoveOnly moved_from_named(std::move(value));
+  REQUIRE(moved_from_named.get().get() == 3);
+}
+
 TEST_CASE("screen_edge_validator") {
   using namespace adm;
   struct ScreenEdgeLockTag {};


### PR DESCRIPTION
I think the first part of this is fairly obvious and worth merging soon, but i'm not sure about the move stuff.

`getNamedTypeDefault` is different from `getDefault` for two reasons:

- it performs a different function; `getNamedTypeDefault` is just to make default-constructed values valid, whereas `getDefault` is used for ADM defaults. Sometimes these are the same, but not always.
- the default implementation of these needs to be different: the one used by NamedType needs to default-construct the underlying value, while the one for auto base needs to default-construct the final value (which may or may not be a NamedType). If these both had the same behaviour they would either result in infinite recursion, or would only work on NamedTypes. It would be possible to implement this with partial specialisation, but then can't be done with function templates.

I considered having `getNamedTypeDefault` return the underlying value, bu this is a bit messier to write (more types, and you need to specify the tag).

I'm not sure if the defaults should be inlined or not. They seem like a good thing to inline, it's really part of the interface, and most types will use the default implementation, which will be inlined anyway.

The main reason i'm not sure about the move stuff is that the new `T get() &&` will sometimes get called when you call `.get()` on a temporary, which is not ideal because it results in a call to `getNamedTypeDefault` and the validator. This means that it is absolutely necessary to implement `getNamedTypeDefault` for types with validators which don't accept default-constructed values, as otherwise `.get()` can throw a cryptic error.