### PR TITLE
Loosen blockformat ID validation to allow for S-ADM frames

### DIFF
--- a/include/adm/elements/audio_channel_format.hpp
+++ b/include/adm/elements/audio_channel_format.hpp
@@ -376,6 +376,12 @@ namespace adm {
     }
   }
 
+  namespace detail {
+    inline bool isValidCounterIncrement(AudioBlockFormatIdCounter const previous, AudioBlockFormatIdCounter const current) {
+      return previous == 0u || current == previous.get() + 1u;
+    }
+  }
+
   template <typename BlockFormat>
   void AudioChannelFormat::assignId(BlockFormat &blockFormat,
                                     BlockFormat *previousBlock) {
@@ -408,13 +414,12 @@ namespace adm {
         throw std::runtime_error("Invalid ID - incorrect value");
 
       if (previousBlock) {
-        int thisCounterValue =
-            thisId.template get<AudioBlockFormatIdCounter>().get();
-        auto prevId = previousBlock->template get<AudioBlockFormatId>();
-        int expectedCounterValue =
-            prevId.template get<AudioBlockFormatIdCounter>().get() + 1;
-        if (thisCounterValue != expectedCounterValue)
+        auto currentCounter = thisId.template get<AudioBlockFormatIdCounter>();
+        auto previousCounter = previousBlock->template get<AudioBlockFormatId>()
+                                   .template get<AudioBlockFormatIdCounter>();
+        if (!detail::isValidCounterIncrement(previousCounter, currentCounter)) {
           throw std::runtime_error("Invalid ID - unexpected counter");
+        }
       }
     }
   }


### PR DESCRIPTION
An audioChannelFormat in an S-ADM frame can contain a set of AudioBlockFormats with an initialiser block.
This is a special block that has a counter value of 0. It may also contain a run of contiguous blocks that start from some integer n > 1. This commit allows non-contiguous IDs to be added to a document for this case only.