### PR TITLE
Fix formatting for updated CI clang-format

### DIFF
--- a/include/adm/detail/named_type_validators.hpp
+++ b/include/adm/detail/named_type_validators.hpp
@@ -51,8 +51,8 @@ namespace adm {
       static void validate(const T& value) {
         if (value > maxValue || value < minValue) {
           std::stringstream msg;
-          msg << "'" << value << "'"
-              << " is not in range [" << minValue << "," << maxValue << "]";
+          msg << "'" << value << "'" << " is not in range [" << minValue << ","
+              << maxValue << "]";
           throw OutOfRangeError(msg.str());
         }
       }

--- a/include/adm/elements/audio_object.hpp
+++ b/include/adm/elements/audio_object.hpp
@@ -259,8 +259,8 @@ namespace adm {
     /// @brief Add reference to a complementary AudioObject
     ADM_EXPORT bool addComplementary(std::shared_ptr<AudioObject> object);
     /// @brief Get references to complementary AudioObjects
-    ADM_EXPORT const std::vector<std::shared_ptr<AudioObject>>
-        &getComplementaryObjects() const;
+    ADM_EXPORT const std::vector<std::shared_ptr<AudioObject>> &
+    getComplementaryObjects() const;
     /// @brief Remove reference to a complementary AudioObject
     ADM_EXPORT void removeComplementary(
         const std::shared_ptr<AudioObject> &object);

--- a/include/adm/utilities/element_io.hpp
+++ b/include/adm/utilities/element_io.hpp
@@ -4,8 +4,8 @@
 namespace adm {
 
   template <class Element>
-  auto operator<<(std::ostream& os, const Element& element)
-      -> decltype(element.print(os), os) {
+  auto operator<<(std::ostream& os,
+                  const Element& element) -> decltype(element.print(os), os) {
     element.print(os);
     return os;
   }


### PR DESCRIPTION
The default clang-format has been updated on github's default runners, resulting in slightly different formatting for a few files. This PR applies the new formatting.