### PR TITLE
Print clang-format version before performing formatting

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+clang-format --version
 DIRS="examples include src tests"
 
 IGNORE="


### PR DESCRIPTION
Differing clang-format versions on developer machines and CI cause the formatting check to fail. Printing out the version prior to formatting should make the cause of failure more obvious.