### PR TITLE
Update version of cache action used in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.ccache
           key: ${{ env.CCACHE_KEY }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
v1 has now been sunset, so we must upgrade.