### PR TITLE
Remove redundant semicolons after constructor bodies

### DIFF
--- a/include/adm/private/copy.hpp
+++ b/include/adm/private/copy.hpp
@@ -101,7 +101,7 @@ namespace adm {
   class ParameterEqualTo {
    public:
     explicit ParameterEqualTo(const Element& element)
-        : parameter_(element.template get<Parameter>()){};
+        : parameter_(element.template get<Parameter>()) {}
 
     inline bool operator()(const Element& other) const {
       return parameter_ == other.template get<Parameter>();

--- a/src/elements/audio_programme.cpp
+++ b/src/elements/audio_programme.cpp
@@ -196,5 +196,5 @@ namespace adm {
   }
 
   AudioProgramme::AudioProgramme(AudioProgrammeName name)
-      : name_(std::move(name)){};
+      : name_(std::move(name)) {}
 }  // namespace adm

--- a/src/elements/position.cpp
+++ b/src/elements/position.cpp
@@ -6,7 +6,7 @@ namespace adm {
 
   // ---- Constructor ---- //
   SphericalPosition::SphericalPosition(Azimuth azimuth, Elevation elevation)
-      : azimuth_(azimuth), elevation_(elevation){};
+      : azimuth_(azimuth), elevation_(elevation) {}
 
   // ---- Defaults ---- //
   const Distance SphericalPosition::distanceDefault_ = Distance(1.f);
@@ -68,7 +68,7 @@ namespace adm {
   // ---- CARTESIAN POSITION ---- //
 
   // ---- Constructor ---- //
-  CartesianPosition::CartesianPosition(X x, Y y) : x_(x), y_(y){};
+  CartesianPosition::CartesianPosition(X x, Y y) : x_(x), y_(y) {}
 
   // ---- Defaults ---- //
   const Z CartesianPosition::zDefault_ = Z(0.f);

--- a/src/private/rapidxml_wrapper.cpp
+++ b/src/private/rapidxml_wrapper.cpp
@@ -51,7 +51,7 @@ namespace adm {
     // ---- XML NODE WRAPPER ---- //
 
     XmlNode::XmlNode(NodePtr node, bool discardDefaults)
-        : node_(node), discardDefaultValues_(discardDefaults){};
+        : node_(node), discardDefaultValues_(discardDefaults) {}
 
     void XmlNode::setValue(const std::string &value) {
       auto valueString = node_->document()->allocate_string(value.c_str());


### PR DESCRIPTION
This was causing formatting issues as they were mistaken for braced initialisers, and it made the code harder to read for humans too.